### PR TITLE
Conversion to unix file format + rm trail whites

### DIFF
--- a/DBSR_HF/dbsr_hf.f90
+++ b/DBSR_HF/dbsr_hf.f90
@@ -10,7 +10,7 @@
 !     case, the program allows also simultaineous calculation of
 !     several configurations in different optimization schemes.
 !     Another possibility - calculation whole Rydberg series in
-!     frozen-core approximation.   
+!     frozen-core approximation.
 !
 !     For short instructions, run dbsr_hf ? and look in name.inp.
 !----------------------------------------------------------------------
@@ -42,7 +42,7 @@
 
       t4=RRTC()
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'Get_estimates:',t4-t3,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'Get_estimates:',t4-t3,'  sec'
 
       t3=RRTC()
 
@@ -50,7 +50,7 @@
 
       t4=RRTC()
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'Solve_HF:',t4-t3,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'Solve_HF:',t4-t3,'  sec'
 
 ! ... output of results:
 
@@ -70,16 +70,16 @@
       Call Summry
       t4=RRTC()
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'Summry:',t4-t3,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'Summry:',t4-t3,'  sec'
 
       t2=RRTC()
-      write(scr,'(/a,f10.2,a)') 'time:',t2-t1,'  sec' 
-      write(log,'(/a,f10.2,a)') 'time:',t2-t1,'  sec' 
+      write(scr,'(/a,f10.2,a)') 'time:',t2-t1,'  sec'
+      write(log,'(/a,f10.2,a)') 'time:',t2-t1,'  sec'
 
       if(debug.gt.0) &
-      write(scr,'(a,T25,f10.2,a,i10)') 'Convol:',time_convol,'  sec',ic_convol 
+      write(scr,'(a,T25,f10.2,a,i10)') 'Convol:',time_convol,'  sec',ic_convol
       if(debug.gt.0) &
-      write(scr,'(a,T25,f10.2,a,i10)') 'Density:',time_density,'  sec',ic_density 
+      write(scr,'(a,T25,f10.2,a,i10)') 'Density:',time_density,'  sec',ic_density
 
       End ! Program DBSR_HF
 

--- a/DBSR_HF/dbsr_lib_dbs.f90
+++ b/DBSR_HF/dbsr_lib_dbs.f90
@@ -151,7 +151,7 @@
        write(*,*) 'rrms is change to 2.0 because GETCPR routine from GRASP'
        write(*,*) 'is nor working for small values of rrms'
        write(*,'(70("_")/)')
-      end if  
+      end if
 
       atomic_number = z
       atomic_weight = atw

--- a/DBSR_HF/dbsr_lib_zcom.f90
+++ b/DBSR_HF/dbsr_lib_zcom.f90
@@ -1159,7 +1159,7 @@
       Subroutine Find_free_unit(nu)
 !======================================================================
 !     provide free unit to open new file
-!----------------------------------------------------------------------	
+!----------------------------------------------------------------------
       Implicit none
       Integer :: nu,i
       Logical :: connected
@@ -1765,7 +1765,7 @@
       E_dcwf = -(1.d0-E)*C*C
 
       End Function E_dcwf
-	
+
 
 !========================================================================
       SUBROUTINE DCME(n,kappa,z,ar1,ar2,am1,am2,am3)
@@ -1883,7 +1883,7 @@
                  two*g*(two*dk+p*E)*cp(ip) )
 
       End Subroutine  Exp_dcwf
-	
+
 
 
 

--- a/DBSR_HF/dbsr_lib_zconfjj.f90
+++ b/DBSR_HF/dbsr_lib_zconfjj.f90
@@ -3711,7 +3711,7 @@ CONTAINS
          io = i
          Do i1=k,kk
           if(SUM(II(i1,k:kk)).eq.1) Cycle; isym1=i1; Exit
-         End do 		
+         End do
          Do i2=k,kk
           if(SUM(II(k:kk,i2)).eq.1) Cycle; isym2=i2; Exit
          End do
@@ -3720,7 +3720,7 @@ CONTAINS
          k1 = isym1+1
          k2 = isym2+1
         end if
-		
+
 	       if(idif.eq.0) Cycle
 
 ! ... second orbital:
@@ -3728,7 +3728,7 @@ CONTAINS
         jo = i
         Do i1=k1,kk
          if(SUM(II(i1,k:kk)).eq.1) Cycle; jsym1=i1; Exit
-        End do 		
+        End do
         Do i2=k2,kk
          if(SUM(II(k:kk,i2)).eq.1) Cycle; jsym2=i2; Exit
         End do

--- a/DBSR_HF/hf_MOD_dbsr_hf.f90
+++ b/DBSR_HF/hf_MOD_dbsr_hf.f90
@@ -10,11 +10,11 @@
 ! ... input/output files and units:
 
       Integer, parameter :: ma = 80   ! limit for file-name length
-      Character(ma) :: AF     
+      Character(ma) :: AF
 
       Integer :: inp = 5;   Character(ma) :: AF_dat  = 'name.inp'
                             Character(ma) :: BF_dat  = '.inp'
-      Integer :: log = 3;   Character(ma) :: AF_log  = 'name.log'                            
+      Integer :: log = 3;   Character(ma) :: AF_log  = 'name.log'
                             Character(ma) :: BF_log  = '.log'
       Integer :: scr = 0
       Integer :: nuw = 11;  Character(ma) :: AF_inp  = 'name.bsw'
@@ -41,7 +41,7 @@
       Character(ma) :: name = ' '
       Character(ma) :: knot = 'knot.dat'
 
-! ... atomic parameters: 
+! ... atomic parameters:
 
       Real(8) :: z = 0.d0
       Integer :: an = 0, ai = 0
@@ -74,16 +74,16 @@
       Integer :: debug  = 0
       Integer :: newton = 0
       Integer :: rotate = 0
-      
-! ... core 
+
+! ... core
 
       Integer,parameter :: mcore = 50
       Character(250) :: core=' '
       Integer :: ncore = 0
-      Integer :: n_core(mcore), k_core(mcore),l_core(mcore),j_core(mcore) 
+      Integer :: n_core(mcore), k_core(mcore),l_core(mcore),j_core(mcore)
       Character(5) :: e_core(mcore)
 
-! ... description of 1 conf.w.function:  
+! ... description of 1 conf.w.function:
 
       Integer, parameter :: msh = 31 ! max. number of shells behind core
       Integer :: no
@@ -93,7 +93,7 @@
 
       Character(9*msh+9) :: CONFIG, SHELLJ, INTRAJ
 
-! ... orbital variables that depend on nwf 
+! ... orbital variables that depend on nwf
 
       Integer :: nwf = 0
       Integer :: nit = 0
@@ -104,11 +104,11 @@
       Integer :: jmin = -1
       Integer :: jmax = -1
 
-! ... output of Breit corrections:  
+! ... output of Breit corrections:
 
-      Integer :: mbreit =  0      
-      Integer :: mode_SE =  3      
-      Integer :: mode_VP =  1      
+      Integer :: mbreit =  0
+      Integer :: mode_SE =  3
+      Integer :: mode_VP =  1
       Real(8) :: eps_c = 1.d-6
       Integer :: ibi = 2**16
 
@@ -121,7 +121,7 @@
       Integer :: out_w = 0     ! output in the GRASP format
       Integer :: out_plot = 0  ! output in table form
 
-! ... frequently called functions: (instead interface)  
+! ... frequently called functions: (instead interface)
 
       Integer, external :: Icheck_file
 

--- a/DBSR_HF/hf_MOD_df_orbitals.f90
+++ b/DBSR_HF/hf_MOD_df_orbitals.f90
@@ -1,7 +1,7 @@
 !=======================================================================
       Module df_orbitals
 !=======================================================================
-!     contains description of atomic orbitals 
+!     contains description of atomic orbitals
 !-----------------------------------------------------------------------
       Implicit none
 
@@ -26,7 +26,7 @@
 !=======================================================================
       Subroutine alloc_df_orbitals(n)
 !=======================================================================
-!     allocates, deallocates or reallocate arrays in module DF_orbiyals 
+!     allocates, deallocates or reallocate arrays in module DF_orbiyals
 !-----------------------------------------------------------------------
       Use df_orbitals
       Implicit none
@@ -40,13 +40,13 @@
                ebs(nbf),e(nbf,nbf),iord(nbf),qsum(nbf),dpm(nbf),clsd(nbf))
       nbs=0; kbs=0; ibs=0; mbs=0; lbs=0; jbs=0; iord=0
       qsum=0.d0; dpm=0.d0; clsd = .false.
- 
+
       End Subroutine alloc_DF_orbitals
 
 !=======================================================================
       Subroutine alloc_DF_radial(ns)
 !=======================================================================
-!     allocates or deallocates radial one-electron functions 
+!     allocates or deallocates radial one-electron functions
 !-----------------------------------------------------------------------
       Use DBS_grid, only: ks
       Use df_orbitals
@@ -62,7 +62,7 @@
       Integer Function Ifind_orb(n,k,iset)
 !=======================================================================
 !     find orbital (n,k,iset) in the list DF_orbitals
-!----------------------------------------------------------------------      
+!----------------------------------------------------------------------
       Use df_orbitals
       Implicit none
       Integer, intent(in) :: n,k,iset
@@ -94,7 +94,7 @@
 !=======================================================================
       Subroutine Put_pv(i,v)
 !=======================================================================
-!     put two-component vector "v" in p-array, location "i" 
+!     put two-component vector "v" in p-array, location "i"
 !-----------------------------------------------------------------------
       Use DBS_grid
       Use DF_orbitals

--- a/DBSR_HF/hf_MOD_energy.f90
+++ b/DBSR_HF/hf_MOD_energy.f90
@@ -2,12 +2,12 @@
       Module hf_energy
 !=======================================================================
 !     This module defines the energy expression as sum  of
-!     one-electron       Sum_i  qsum(i) valueI (i)   
-!     and two-electron   Sum_i,j,k  coef(i,j,k)  value(i,j,k)  
+!     one-electron       Sum_i  qsum(i) valueI (i)
+!     and two-electron   Sum_i,j,k  coef(i,j,k)  value(i,j,k)
 !     integrals.   value(i,j,k) ->  Fk(i,j) or Gk(i,j) integrals,
-!     which is defined by subroutines a(i,j,k) and b(i,j,k). 
+!     which is defined by subroutines a(i,j,k) and b(i,j,k).
 !     Note that coef(i,j,k) with i > = j refer to direct Fk-integrals
-!     whereas coef(i,j,k) with i < j refer to exchage Gk-integrals. 
+!     whereas coef(i,j,k) with i < j refer to exchage Gk-integrals.
 !----------------------------------------------------------------------
       Implicit none
 
@@ -36,7 +36,7 @@
 
 
 !=======================================================================
-      Real(8) Function b(i,j,k) 
+      Real(8) Function b(i,j,k)
 !=======================================================================
 !     determine the coefficient of the y^k (i,j) p(j) term in the exchange
 !     expression for electron i
@@ -51,9 +51,9 @@
       if(i.eq.j) Return
       if(mod(k+lbs(i)+lbs(j),2) /= 0) Return
       if( k < abs(jbs(i)-jbs(j))/2 ) Return
-      if( k > (jbs(i)+jbs(j))/2 ) Return 
+      if( k > (jbs(i)+jbs(j))/2 ) Return
       b = coef(min(i,j),max(i,j),k)
-    
+
       End Function b
 
 
@@ -92,7 +92,7 @@
 !======================================================================
 !     Angular coefficients for energy in average-term approximation
 !
-!     Into shell, only direct interaction:  
+!     Into shell, only direct interaction:
 !
 !     q(q-1)/2 [ F0(a,a)  -  (2j+1)/2j  { j  k   j } ^2  Fk(a,a)  ]
 !                                       {1/2 0 -1/2}
@@ -100,9 +100,9 @@
 !     Between shells: direct only k=0
 !
 !     q_a*q_b/2 [ F0(a,b) -   {j_a  k j_b} ^2  Gk(a,b)   ]
-!                             {1/2 0 -1/2}            
+!                             {1/2 0 -1/2}
 !
-!     We devide on (2ja+1)(2jb+1) due to using Function Cjkj instead 3J-symbol 
+!     We devide on (2ja+1)(2jb+1) due to using Function Cjkj instead 3J-symbol
 !----------------------------------------------------------------------
       Use hf_energy
       Use df_orbitals
@@ -111,8 +111,8 @@
       Integer, intent(in) :: jj
       Integer :: i,j, k
       Real(8) :: c
-      Real(8), external :: Cjkj, WW 
-	  
+      Real(8), external :: Cjkj, WW
+
       if(jj.le.0) Return
       Do i = 1,nbf
       Do j = 1,i
@@ -131,8 +131,8 @@
         End do
        end if
       End do; End do
-	  
-      End Subroutine av_energy_coef 
+
+      End Subroutine av_energy_coef
 
 
 !======================================================================
@@ -143,13 +143,13 @@
 !======================================================================
       Use dbsr_hf
       Use DF_orbitals
-      
+
       Implicit none
-      Integer, Intent(in) :: i,j 
+      Integer, Intent(in) :: i,j
       Integer :: ic
 
       if(nconf.eq.1) then
-       if(i.eq.j) WW = qsum(i)*(qsum(i)-1.d0)       
+       if(i.eq.j) WW = qsum(i)*(qsum(i)-1.d0)
        if(i.ne.j) WW = qsum(i)*qsum(j)
        Return
       end if
@@ -187,15 +187,15 @@
        if(ii.ne.0.and.i.ne.ii) Cycle
 
        valueI(i) = Vp_dhl (kbs(i),p(1,1,i),kbs(i),p(1,1,i))
- 
-       Do j = 1,i  ! nbf 
+
+       Do j = 1,i  ! nbf
         Do  k = 0,2*min0(l(i),l(j)),2
          if(a(i,j,k).eq.0.d0) Cycle
          value(i,j,k) = hf_fk(i,j,k)
        End do
-       End do 
- 
-       Do  j = 1,i-1 ! nbf 
+       End do
+
+       Do  j = 1,i-1 ! nbf
         Do k = abs(l(i)-l(j)),l(i)+l(j),2
          if(b(i,j,k).eq.0.d0) Cycle
          value(j,i,k) = hf_gk(i,j,k)
@@ -210,7 +210,7 @@
 !======================================================================
       Subroutine energy
 !======================================================================
-!     Determine the total energy of the state, together with                                                                
+!     Determine the total energy of the state, together with
 !     one-electron and two-electron (direct and exchange) parts
 !----------------------------------------------------------------------
       Use hf_energy
@@ -232,18 +232,18 @@
        Do j = 1,i
         Do  k = 0,2*min0(l(i),l(j)),2
          c = a(i,j,k); if(c.eq.0.d0) Cycle
-         S = value(i,j,k)                        
+         S = value(i,j,k)
          etotal = etotal + c*S
          E2body = E2body + c*S
         End do
-       End do 
+       End do
 
 ! ... exchange interaction
- 
+
        Do  j = 1,i-1
         Do k = abs(l(i)-l(j)),l(i)+l(j),2
          c = b(i,j,k); ; if(c.eq.0.d0) Cycle
-         S = value(j,i,k)                         
+         S = value(j,i,k)
          etotal = etotal + c*S
          E2body = E2body + c*S
         End do
@@ -269,11 +269,11 @@
       Integer :: i,j,k, ic,jc, ii,jj, km
       Real(8) :: c
       Real(8), allocatable :: coefs(:,:,:)
-      Integer, external :: Ifind_orb 
+      Integer, external :: Ifind_orb
 
       rewind(nuc)
       ic = 0
-      Do 
+      Do
        read(nuc,'(a)') CONFIG
        if(CONFIG(6:6).ne.'(') Cycle
        read(nuc,'(a)') SHELLJ
@@ -292,14 +292,14 @@
        Do k=0,kmax
         C = coefs(i,j,k); if(abs(C).lt.eps_c) C=0.d0
         if(C.eq.0.d0) Cycle
-        coef(ii,jj,k) = coef(ii,jj,k) + C * weight(ic)  
+        coef(ii,jj,k) = coef(ii,jj,k) + C * weight(ic)
        End do; End do; End do
        Deallocate(coefs)
 
        if(jc.ne.0.and.ic.eq.jc) Exit
        if(ic.eq.nconf) Exit
       End do  ! over configurations
-  
-      End Subroutine jj_energy_coef 
+
+      End Subroutine jj_energy_coef
 
 

--- a/DBSR_HF/hf_boundary.f90
+++ b/DBSR_HF/hf_boundary.f90
@@ -6,7 +6,7 @@
 !--------------------------------------------------------------------
       Use dbsr_hf
       Use DBS_nuclear
-      Use DBS_grid     
+      Use DBS_grid
       Use df_orbitals
 
       Implicit none
@@ -15,16 +15,16 @@
       iprm=1
       if(nuclear.eq.'point'.or.ilzero.eq.0) then
        Do i=1,nbf
-        iprm(1,i)=0;    j=nsp-ibzero+1; iprm(j:ns,i)=0  
-        iprm(ns+1,i)=0; j=nsq-ibzero+1; iprm(j+ns:ms,i)=0  
+        iprm(1,i)=0;    j=nsp-ibzero+1; iprm(j:ns,i)=0
+        iprm(ns+1,i)=0; j=nsq-ibzero+1; iprm(j+ns:ms,i)=0
        End do
       else
        Do i=1,nbf
-        j=lbs(i)+1; if(j.gt.ksp-1) j=1; iprm(1:j,i)=0 
-        j=nsp-ibzero+1; iprm(j:ns,i)=0 
+        j=lbs(i)+1; if(j.gt.ksp-1) j=1; iprm(1:j,i)=0
+        j=nsp-ibzero+1; iprm(j:ns,i)=0
         if(kbs(i).lt.0) j=lbs(i)+2
         if(kbs(i).ge.1) j=lbs(i)
-        if(j.gt.ksq-1) j=1;  iprm(ns+1:ns+j,i)=0 
+        if(j.gt.ksq-1) j=1;  iprm(ns+1:ns+j,i)=0
         j=nsq-ibzero+1; iprm(j+ns:ms,i)=0
        End do
       end if
@@ -32,4 +32,3 @@
       End Subroutine Boundary_conditions
 
 
-       

--- a/DBSR_HF/hf_check_tails.f90
+++ b/DBSR_HF/hf_check_tails.f90
@@ -8,7 +8,7 @@
       Use dbsr_hf
       Use DBS_grid
       Use df_orbitals
-      
+
       Implicit none
       Integer :: io,jo,i
       Real(8) :: cm
@@ -16,15 +16,14 @@
       Do io=1,nbf; if(jo.ne.0.and.io.ne.jo) Cycle
        cm = maxval( abs( p(:,1,io) ) )
        Do i=nsp-1,1,-1
-        mbs(io)=i     
+        mbs(io)=i
         if(abs(p(i,1,io))/cm.lt.end_tol) Cycle
         Exit
        End do
        p(i+1:ns,1,io)=0.d0
        p(i+1:ns,2,io)=0.d0
       End do
-      Call Boundary_conditions 
+      Call Boundary_conditions
 
       End Subroutine Check_tails
 
-       

--- a/DBSR_HF/hf_def_conf_LS.f90
+++ b/DBSR_HF/hf_def_conf_LS.f90
@@ -8,7 +8,7 @@
 
       Implicit none
       Character(160) :: conf
-      Integer :: iqsum(msh),iq_min(msh),iq_max(msh) 
+      Integer :: iqsum(msh),iq_min(msh),iq_max(msh)
       Integer :: i,j,ii,m
 
       Integer, parameter :: morb=100
@@ -40,7 +40,7 @@
       read(nus,'(/a)') core
       nconf=0
 
-      Do 
+      Do
        read(nus,'(a)',end=10,err=10) conf
        if(index(conf,'(').eq.0) Cycle
        Call Decode_conf_LS(conf,no,nn,ln,iq,in)
@@ -62,11 +62,11 @@
          norb=norb+1; EL(norb)=EL1
         End do
 
-        i=no; iq=iq_max 
+        i=no; iq=iq_max
       1 ii=SUM(iq(1:no))
 
         if(ii.eq.nelc) then
- 
+
          m = 0
          Do j=1,no; if(ln(j).eq.0) Cycle
           if(j.gt.1) then; if(ln(j).eq.ln(j-1)) Cycle; end if
@@ -108,7 +108,7 @@
        write(nuc,'(a)') trim(conf)
       End do
       write(nuc,'(a)') '*'
-      Close(nuc)      
+      Close(nuc)
 
       Close(nua,status='DELETE')
       Close(nus)
@@ -136,7 +136,7 @@ CONTAINS
 
 ! ... record configuration
 
-      i = len_trim(conf) 
+      i = len_trim(conf)
       if(i.le.72) then
        write(nua,'(a,T73,F12.4)') conf(1:i),W
       else
@@ -153,7 +153,7 @@ CONTAINS
 !=========================================================================
       Subroutine Decode_conf_jj(configuration,no,nn,kn,ln,jn,iq,in)
 !=========================================================================
-! ... decode the spectroscopic configuration into "integer" representation 
+! ... decode the spectroscopic configuration into "integer" representation
 !-------------------------------------------------------------------------
       Implicit none
       Character(*) :: configuration
@@ -163,7 +163,7 @@ CONTAINS
 
       Call Clean_a(configuration)
       no=0; start=1
-      Do  
+      Do
        i1 = index(configuration(start:),'(')
        if(i1.eq.0) Exit
        i1=i1+start-1
@@ -224,7 +224,7 @@ CONTAINS
 !=========================================================================
       Subroutine Incode_conf_LS(configuration,no,nn,ln,iq,in)
 !=========================================================================
-! ... incode the spectroscopic configuration into "integer" representation 
+! ... incode the spectroscopic configuration into "integer" representation
 !-------------------------------------------------------------------------
       Implicit none
       Character(*) :: configuration
@@ -233,7 +233,7 @@ CONTAINS
       Character(1), external :: AL
 
       m=1; configuration = ' '
-      Do i=1,no 
+      Do i=1,no
        if(in(i).eq.0) then
         write(configuration(m:),'(i3,a1)') nn(i),AL(ln(i),1)
        else
@@ -249,7 +249,7 @@ CONTAINS
 !=========================================================================
       Subroutine Decode_conf_LS(configuration,no,nn,ln,iq,in)
 !=========================================================================
-! ... decode the spectroscopic configuration into "integer" representation 
+! ... decode the spectroscopic configuration into "integer" representation
 !-------------------------------------------------------------------------
       Implicit none
       Character(*) :: configuration
@@ -259,7 +259,7 @@ CONTAINS
 
       Call Clean_a(configuration)
       no=0; start=1
-      Do  
+      Do
        i1 = index(configuration(start:),'(')
        if(i1.eq.0) Exit
        i1=i1+start-1
@@ -292,7 +292,7 @@ CONTAINS
       n=0
       Do i=1,no; l=l1(i)
 
-       if(l.eq.0) then 
+       if(l.eq.0) then
         j=l+l+1; k=(l+l-j)*(j+1)/2
         n = n + 1
         nn(n) = n1(i); kn(n)=k; ln(n)=l; jn(n)=j; iq(n)=0; in(n)=i1(i)

--- a/DBSR_HF/hf_def_conf_jj.f90
+++ b/DBSR_HF/hf_def_conf_jj.f90
@@ -11,7 +11,7 @@
       Integer :: i,j,ic,io,is,k,iset
       Integer, external :: Jdef_ncfg, Ifind_position, Ifind_orb, &
                            Iadd_cfg_jj
-      Character(5), external :: Eli 
+      Character(5), external :: Eli
 
 ! ... check c-file:
 
@@ -84,7 +84,7 @@
       i=Ifind_position(nuc,'CSF(s):')
 
       ic = 0
-      Do 
+      Do
        read(nuc,'(a)') CONFIG
 
        if(CONFIG(6:6).ne.'(') Cycle

--- a/DBSR_HF/hf_energy_BR.f90
+++ b/DBSR_HF/hf_energy_BR.f90
@@ -8,7 +8,7 @@
       Use dbsr_hf
       Use df_orbitals, only: nbf, kbs, ebs
       Use DBS_grid
-      Use rk4_data      
+      Use rk4_data
 
       Implicit none
       Integer :: i,j,k, ki,kj, k1,k2,k3,k4, i1,i2,i3,i4, v
@@ -17,8 +17,8 @@
 
       nrk = 0
       Do i = 1,nbf;  ki=kbs(i)
-      Do j = 1,nbf;  kj=kbs(j) 
- 
+      Do j = 1,nbf;  kj=kbs(j)
+
       if(i.ge.j) then
        k1=ki; k2=kj; k3=ki; k4=kj; i1=i; i2=j; i3=i; i4=j
       else
@@ -30,14 +30,14 @@
        Do v = k-1,k+1
         if(SMU(k1,k2,k3,k4,k,v,S).eq.0.d0) Cycle
         S = S * coef(i,j,k)
-        Call Add_rk4_data(1,v,i1*ibi+i2,i3*ibi+i4,S(1)) 
-        Call Add_rk4_data(1,v,i2*ibi+i1,i4*ibi+i3,S(2)) 
-        Call Add_rk4_data(1,v,i3*ibi+i4,i1*ibi+i2,S(3)) 
-        Call Add_rk4_data(1,v,i4*ibi+i3,i2*ibi+i1,S(4)) 
-        Call Add_rk4_data(1,v,i1*ibi+i4,i3*ibi+i2,S(5)) 
-        Call Add_rk4_data(1,v,i4*ibi+i1,i2*ibi+i3,S(6)) 
-        Call Add_rk4_data(1,v,i3*ibi+i2,i1*ibi+i4,S(7)) 
-        Call Add_rk4_data(1,v,i2*ibi+i3,i4*ibi+i1,S(8)) 
+        Call Add_rk4_data(1,v,i1*ibi+i2,i3*ibi+i4,S(1))
+        Call Add_rk4_data(1,v,i2*ibi+i1,i4*ibi+i3,S(2))
+        Call Add_rk4_data(1,v,i3*ibi+i4,i1*ibi+i2,S(3))
+        Call Add_rk4_data(1,v,i4*ibi+i3,i2*ibi+i1,S(4))
+        Call Add_rk4_data(1,v,i1*ibi+i4,i3*ibi+i2,S(5))
+        Call Add_rk4_data(1,v,i4*ibi+i1,i2*ibi+i3,S(6))
+        Call Add_rk4_data(1,v,i3*ibi+i2,i1*ibi+i4,S(7))
+        Call Add_rk4_data(1,v,i2*ibi+i3,i4*ibi+i1,S(8))
        End do
       End do
 
@@ -46,7 +46,7 @@
       Ebreit = 0.d0
       Do v = 1,nrk; if(abs(crk(v)).lt.eps_c) Cycle
        k = kr2(v)
-       i1 = kr3(v)/ibi; i2=mod(kr3(v),ibi);  i3 = kr4(v)/ibi; i4=mod(kr4(v),ibi) 
+       i1 = kr3(v)/ibi; i2=mod(kr3(v),ibi);  i3 = kr4(v)/ibi; i4=mod(kr4(v),ibi)
        Ebreit = Ebreit + crk(v) * sk_ppqq(i1,i2,i3,i4,k)
       End do
 
@@ -68,7 +68,7 @@
       Integer, External :: ITRA, l_kappa
       Real(8) :: b,c,bp,cp
 
-      SMU = 0.d0; S = 0.d0; if(L.lt.0) Return;  if(v.lt.0) Return 
+      SMU = 0.d0; S = 0.d0; if(L.lt.0) Return;  if(v.lt.0) Return
 
       la=l_kappa(ka); lc=l_kappa(kc)
       if(mod(la+lc+v,2).eq.0) Return
@@ -84,7 +84,7 @@
       else
 
        K=kc-ka; Kp=kd-kb
-       
+
        if(v.eq.L-1) then
 
         bp=L+1; bp=bp/2/(L+L-1); cp=-(L-2); cp=cp/2/L/(L+L-1)
@@ -118,7 +118,7 @@
 
       end if
 
-      End Function SMU 
+      End Function SMU
 
 
 !======================================================================
@@ -133,8 +133,8 @@
 !     int = 2 -->  INT( j,i; j,j)
 !     int = 3 -->  INT( i,j; j,i)
 !     int = 4 -->  INT( j,i; i,j)
-! 3.  i 
-! 4.  j 
+! 3.  i
+! 4.  j
 !----------------------------------------------------------------------
       Use dbsr_hf
       Use hf_energy
@@ -148,36 +148,36 @@
       Call alloc_rk4_data(0)
 
       Do i = 1,nbf;  ki=kbs(i)
-      Do j = 1,nbf;  kj=kbs(j) 
- 
+      Do j = 1,nbf;  kj=kbs(j)
+
       Do k = 0,kmax
        if(coef(i,j,k).eq.0.d0) Cycle
        Do v = k-1,k+1
          if(i.ge.j) then                             !  Rk(i,j,i,j)
           if(SMU(ki,kj,ki,kj,k,v,S).eq.0.d0) Cycle
           S = S * coef(i,j,k)
-          C = Sum(S) 
+          C = Sum(S)
           if(i.eq.j) then
-           C = Sum(S) 
-           Call Add_rk4_data(v,1,i,i,C) 
+           C = Sum(S)
+           Call Add_rk4_data(v,1,i,i,C)
           else
            C = S(1)+S(3)+S(5)+S(7)
-           Call Add_rk4_data(v,1,i,j,C) 
+           Call Add_rk4_data(v,1,i,j,C)
            C = S(2)+S(4)+S(6)+S(8)
-           Call Add_rk4_data(v,2,i,j,C) 
+           Call Add_rk4_data(v,2,i,j,C)
           end if
          else                                       !  Rk(i,j,j,i)
           if(SMU(ki,kj,kj,ki,k,v,S).eq.0.d0) Cycle
           S = S * coef(i,j,k)
           C = S(1)+S(4)
-          Call Add_rk4_data(v,3,i,j,C) 
+          Call Add_rk4_data(v,3,i,j,C)
           C = S(2)+S(3)
-          Call Add_rk4_data(v,4,i,j,C) 
+          Call Add_rk4_data(v,4,i,j,C)
           C = S(5)+S(6)
-          Call Add_rk4_data(v+1000,3,i,j,C) 
+          Call Add_rk4_data(v+1000,3,i,j,C)
           C = S(7)+S(8)
-          Call Add_rk4_data(v+1000,4,i,j,C) 
-         end if  
+          Call Add_rk4_data(v+1000,4,i,j,C)
+         end if
        End do      ! v
       End do       ! k
 
@@ -191,7 +191,7 @@
 !     Breit corrections to Dirac-Coulomb energy
 !     for the generalized configuration
 !----------------------------------------------------------------------
-      Use rk4_data      
+      Use rk4_data
       Use dbsr_hf,  only: kmax, eps_c
       Use DBS_grid, only: ns,ks
 
@@ -207,10 +207,10 @@
        k = mod(kr1(m),1000); atype=kr1(m)/1000
        int = kr2(m); i = kr3(m); j = kr4(m)
        Select case(int)
-        Case(1);   i1 = i; i2 = j;  i3 = i; i4 = j 
-        Case(2);   i1 = j; i2 = i;  i3 = j; i4 = i 
-        Case(3);   i1 = i; i2 = j;  i3 = j; i4 = i 
-        Case(4);   i1 = j; i2 = i;  i3 = i; i4 = j 
+        Case(1);   i1 = i; i2 = j;  i3 = i; i4 = j
+        Case(2);   i1 = j; i2 = i;  i3 = j; i4 = i
+        Case(3);   i1 = i; i2 = j;  i3 = j; i4 = i
+        Case(4);   i1 = j; i2 = i;  i3 = i; i4 = j
        End Select
        if(atype.eq.0)  Ebreit = Ebreit + crk(m) * sk_ppqq(i1,i2,i3,i4,k)
 

--- a/DBSR_HF/hf_energy_SE.f90
+++ b/DBSR_HF/hf_energy_SE.f90
@@ -25,7 +25,7 @@
        ZR_nucl = 0.d0
        Do i=1,nv; Do j=1,ks
         if(gr(i,j).le.0.0219) ZR_nucl(i,j) = grw(i,j)
-       End do; End do 
+       End do; End do
       end if
 
       Call ZINTYm (nv,ks,ksp,ksp,pbsp,pbsp,ZR_nucl,ns,fp_nucl)
@@ -40,7 +40,7 @@
              xAy(ns,ks,fq_nucl,'f',Qcoef,Qcoef)
        S2 =  xAy(ns,ks,fp_nucl,'f',p(1,1,i),p(1,1,i)) +  &
              xAy(ns,ks,fq_nucl,'f',p(1,2,i),p(1,2,i))
-       ratio = S2/S1 
+       ratio = S2/S1
        if(debug.gt.0) &
        write(log,'(a,a,f15.5)') 'SE_ratio:  ',ebs(i),ratio
        Se = Se + ratio * relci_qed_F(nbs(i),kbs(i),z) * qsum(i) * &
@@ -57,7 +57,7 @@
 
    function relci_qed_F(n,kappa,Z)                             result(F)
    !--------------------------------------------------------------------
-   ! Estimates the function  F (Z*\alpha) by using an interpolation of 
+   ! Estimates the function  F (Z*\alpha) by using an interpolation of
    ! tabulated data from Mohr (1983) or Mohr and Kim (1992).
    !
    ! Calls: relci_qed_F_Mohr(), relci_qed_F_Mohr_Kim().
@@ -85,10 +85,10 @@
    !--------------------------------------------------------------------
    ! Estimates the function  F (Z*\alpha) by using a series expansion
    ! from S Klarsfeld and A Maquet, Physics Letters  43B (1973) 201,
-   ! Eqs (1) and (2) and the table of Bethe logarithms. The 
-   ! vacuum-polarization contribution in Eq (2) is omitted. 
+   ! Eqs (1) and (2) and the table of Bethe logarithms. The
+   ! vacuum-polarization contribution in Eq (2) is omitted.
    ! This procedure is adapted from RCI92 of GRASP92, written
-   ! by Farid A Parpia, to the Fortran 95 standard. 
+   ! by Farid A Parpia, to the Fortran 95 standard.
    !
    ! This procedure is not used in the current version.
    !--------------------------------------------------------------------
@@ -110,7 +110,7 @@
            -0.0004079_dp,   2.7324291_dp,  -0.0461552_dp,  -0.0085192_dp, &
            -0.0027091_dp,  -0.0010945_dp,  -0.0004997_dp,  -0.0002409_dp, &
             2.7302673_dp,  -0.0467413_dp,  -0.0087850_dp,  -0.0028591_dp, &
-           -0.0011904_dp,  -0.0005665_dp,  -0.0002904_dp,  -0.0001539_dp /) 
+           -0.0011904_dp,  -0.0005665_dp,  -0.0002904_dp,  -0.0001539_dp /)
       !
       real(kind=dp), parameter :: C401 = 11.0_dp/24.0_dp,                 &
                                C402 = 3.0_dp/8.0_dp, ovlfac = 4.0_dp/3.0_dp
@@ -156,14 +156,14 @@
    !
    function relci_qed_F_Mohr(n,kappa,Z)                        result(F)
    !--------------------------------------------------------------------
-   ! Computes the function  F (Z*\alpha) for the  1s  2s  2p-  2p  
-   ! symmetries by interpolating in, or extrapolating from, the table 
-   ! due to  P J Mohr. See  P J Mohr, At Data Nucl Data Tables 29 
-   ! (1983) 453. 
+   ! Computes the function  F (Z*\alpha) for the  1s  2s  2p-  2p
+   ! symmetries by interpolating in, or extrapolating from, the table
+   ! due to  P J Mohr. See  P J Mohr, At Data Nucl Data Tables 29
+   ! (1983) 453.
    ! This procedure is adapted from RCI92 of GRASP92, written
    ! by Farid A Parpia, to the Fortran 95 standard.
    !
-   ! Calls: 
+   ! Calls:
    !--------------------------------------------------------------------
       Use zconst
       Implicit none
@@ -235,12 +235,12 @@
    !
    function relci_qed_F_Mohr_Kim(n,kappa,Z)                    result(F)
    !--------------------------------------------------------------------
-   ! Computes the function  F (Z*\alpha) for the  1s  2s  2p-  2p  
-   ! symmetries by interpolating in, or extrapolating from, the table 
-   ! due to  P J Mohr and Y-K Kim. See P J Mohr and Y-K Kim, 
+   ! Computes the function  F (Z*\alpha) for the  1s  2s  2p-  2p
+   ! symmetries by interpolating in, or extrapolating from, the table
+   ! due to  P J Mohr and Y-K Kim. See P J Mohr and Y-K Kim,
    ! Phys. Rev. A45 (1992) 2723.
    !
-   ! Since no values are given for Z = 1, these values were estimated 
+   ! Since no values are given for Z = 1, these values were estimated
    ! below by (graphical) extrapolation.
    !
    ! Calls: interpolation_aitken().
@@ -400,14 +400,14 @@
 
    subroutine interpolation_aitken(xarr,yarr,narr,xval,yval,accy)
    !--------------------------------------------------------------------
-   ! This routine returns  yval  as the functions value of  xval 
-   ! by interpolating a pair of arrays xarr(1:narr), yarr(1:narr), 
-   ! that tabulate a  function.  Aitken's algorithm is used. See, for  
-   ! instance, F B Hildebrand, Introduction to Numerical Analysis,  
-   ! 2nd ed., McGraw-Hill, New York, NY, 1974. accy is the  desired  
-   ! accuracy of the estimate: a warning message is issued if this is 
-   ! not achieved.  A warning is also issued when the routine is 
-   ! extrapolating. 
+   ! This routine returns  yval  as the functions value of  xval
+   ! by interpolating a pair of arrays xarr(1:narr), yarr(1:narr),
+   ! that tabulate a  function.  Aitken's algorithm is used. See, for
+   ! instance, F B Hildebrand, Introduction to Numerical Analysis,
+   ! 2nd ed., McGraw-Hill, New York, NY, 1974. accy is the  desired
+   ! accuracy of the estimate: a warning message is issued if this is
+   ! not achieved.  A warning is also issued when the routine is
+   ! extrapolating.
    ! This procedures is adapted to Fortran 90/95 from the routine
    ! interp() of GRASP92 which originally was written by F A Parpia.
    !--------------------------------------------------------------------
@@ -526,7 +526,7 @@
          !
          function iloc (ind1,ind2)                           result(loc)
          !--------------------------------------------------------------
-         ! This internal function dispenses with the need for a 
+         ! This internal function dispenses with the need for a
          ! two-dimensional array for the interpolation. It replaces a
          ! statement function in the original code.
          !--------------------------------------------------------------

--- a/DBSR_HF/hf_energy_VP.f90
+++ b/DBSR_HF/hf_energy_VP.f90
@@ -5,7 +5,7 @@
 !----------------------------------------------------------------------
       Use dbsr_hf
       Use DF_orbitals
-      Use DBS_nuclear      
+      Use DBS_nuclear
       Use DBS_grid
       Use DBS_gauss
 
@@ -38,15 +38,15 @@
 
       End Subroutine VP_energy
 
- 
-!======================================================================   
+
+!======================================================================
       Subroutine set_vacpol_2(vacpol)
-!======================================================================   
-! Sets up the second-order vacuum polarization potential using  
-! equations (1) and (4) of L W Fullerton and  G A Rinker, Jr,  
-! Phys Rev A  13 (1976) 1283-1287. 
+!======================================================================
+! Sets up the second-order vacuum polarization potential using
+! equations (1) and (4) of L W Fullerton and  G A Rinker, Jr,
+! Phys Rev A  13 (1976) 1283-1287.
 !
-! This routine is similar to vac2 from grasp92 [RCI92] which was 
+! This routine is similar to vac2 from grasp92 [RCI92] which was
 ! written by F A Parpia (see also RATIP)
 !
 ! Calls: vacpol_Kn
@@ -65,16 +65,16 @@
       epsi  = 1.0e-20_dp
       twocv = c_au + c_au
       vacpol = zero
-      
+
 ! ... Potential for a point nucleus, equation (1):
 !                   2 Z
-!     V_2(r) = -  -------- K_1(2cr) 
+!     V_2(r) = -  -------- K_1(2cr)
 !                 3 c pi r
 ! ... (this is also the asymptotic form for a finite nucleus)
 
       factor = -(two * atomic_number)/(three * pi * c_au)
       Do i=1,nv; Do m=1,ks
-       x = twocv * gr(i,m) 
+       x = twocv * gr(i,m)
        vacpol(i,m) = factor/gr(i,m) * vacpol_Kn(x,1)
        if (abs(vacpol(i,m)) < epsi) factor=0.d0
        if(factor.eq.0.d0) Exit
@@ -84,7 +84,7 @@
 
 ! ... Potential for a finite nucleus: equation (4)
 !                    2
-!     V_2(r) = - -------- INT[r',0,inf; r' ro(r') {K_0(2c|r-r'|)-K_0(2c|r+r'|} ] 
+!     V_2(r) = - -------- INT[r',0,inf; r' ro(r') {K_0(2c|r-r'|)-K_0(2c|r+r'|} ]
 !                3 c^2 r
 
       factor = -two / (three * c_au**2)
@@ -106,19 +106,19 @@
       End do; if(x.eq.0.d0) Exit; End do
 
       End Subroutine set_vacpol_2
-   
 
-!======================================================================   
+
+!======================================================================
       Subroutine set_vacpol_4(vacpol)
-!======================================================================   
-! Sets up the fourth-order vacuum polarization potential using 
-! equations (11) and (12) of L Wayne Fullerton and  G A Rinker, Jr,  
+!======================================================================
+! Sets up the fourth-order vacuum polarization potential using
+! equations (11) and (12) of L Wayne Fullerton and  G A Rinker, Jr,
 ! Phys  Rev  A 13 (1976) 1283-1287.
-! This routine is similar to vac4 from GRASP92 [RCI92] which was 
+! This routine is similar to vac4 from GRASP92 [RCI92] which was
 ! written by F A Parpia.
 !
 ! Calls: vacpol_Kn
-! 
+!
 ! Remark: this potential is added to existing one.
 !----------------------------------------------------------------------
       Use DBS_grid
@@ -130,20 +130,20 @@
       Real(kind=dp) :: epsi, factor, twocv, x, xi, xm, xk, xp
       Real(kind=dp) :: vacpol(nv,ks)
       Real(kind=dp), external :: vacpol_Lk
-      
+
       epsi  = 1.0e-20_dp
       twocv = c_au + c_au
 
 ! ... Potential for a point nucleus: equation (12)
 !                     Z
-!     V_4(r) = -  ----------  L_1(2cr) 
+!     V_4(r) = -  ----------  L_1(2cr)
 !                 c^2 pi^2 r
 ! ... (this is also the asymptotic form for a finite nucleus)
 
       factor = -atomic_number / (pi*c_au)**2
 
       Do i=1,nv; Do m=1,ks
-       x = twocv * gr(i,m) 
+       x = twocv * gr(i,m)
        vacpol(i,m) = vacpol(i,m) + factor/gr(i,m) * vacpol_Lk(x,1)
        if (abs(vacpol(i,m)) < epsi) factor=0.d0
        if(factor.eq.0.d0) Exit
@@ -153,7 +153,7 @@
 
 ! ... Potential for finite nucleus: equation (11)
 !                    1
-!     V_4(r) = - -------- INT[r',0,inf; r' V(r') {L_0(2c|r-r'|)-L_0(2c|r+r'|} ] 
+!     V_4(r) = - -------- INT[r',0,inf; r' V(r') {L_0(2c|r-r'|)-L_0(2c|r+r'|} ]
 !                c^3 pi r
 
       if (nuclear.eq.'point') Return
@@ -182,22 +182,22 @@
 !========================================================================
    function vacpol_Kn(x,n)                        result(Kn)
    !--------------------------------------------------------------------
-   ! Evaluates the K_N(X) functions using the analytic functions defined 
-   ! in tables 1 and 3 of Fullerton and Rinker, Phys  Rev  A 13 (1976) 
+   ! Evaluates the K_N(X) functions using the analytic functions defined
+   ! in tables 1 and 3 of Fullerton and Rinker, Phys  Rev  A 13 (1976)
    ! 1283-1287.
-   ! This routine is taken from RATIP and similar to ... from g 
-   ! [RCI92] which was written by F A Parpia; 
+   ! This routine is taken from RATIP and similar to ... from g
+   ! [RCI92] which was written by F A Parpia;
    ! it has been adapted in RATIP to the Fortran90/95 standard.
    !--------------------------------------------------------------------
       Use zconst
 
       Implicit none
-      
+
       integer, intent(in)       :: n
       real(kind=dp), intent(in) :: x
       real(kind=dp)             :: Kn
       !
-      real(kind=dp), dimension(10,4), parameter :: p = reshape(source =   & 
+      real(kind=dp), dimension(10,4), parameter :: p = reshape(source =   &
         (/  8.8357293375e-1_dp, -2.8259817381e-1_dp, -5.8904879578e-1_dp, &
             1.2500133434e-1_dp, -3.2729913852e-2_dp,  8.2888574511e-3_dp, &
            -1.0327765800e-5_dp,  6.3643668900e-5_dp,  0.0_dp,             &
@@ -263,8 +263,8 @@
       if (use_stop   .and.                               &
          (n < 0   .or.   n == 2   .or.   n == 4   .or.  n > 5)) then
          print *, "Attempt to calculate FUNK (X,N) for N other than "// &
-                  "0, 1, 3 and 5."  
-         stop     "vacpol_Kn(): program stop A."   
+                  "0, 1, 3 and 5."
+         stop     "vacpol_Kn(): program stop A."
       end if
       !
       select case(n-3)
@@ -278,7 +278,7 @@
          k  = n-1
          xn = one / (x**4)
       case default
-         stop "vacpol_Kn(): program stop B."   
+         stop "vacpol_Kn(): program stop B."
       end select
       if (x > one) goto 9
       !
@@ -301,7 +301,7 @@
       case(3)
          bsum = bsum * x2
       case default
-         stop "vacpol_Kn(): program stop C."   
+         stop "vacpol_Kn(): program stop C."
       end select
       sum = sum+bsum*log (x)/csum
       !
@@ -325,23 +325,23 @@
       !
    11 if (use_stop   .and.   n /= 0) then
          print *, "Attempt to calculate Kn (0,N) for N > 0."
-         stop     "vacpol_Kn(): program stop D."   
+         stop     "vacpol_Kn(): program stop D."
       end if
       !
       Kn  = p(1,1)
       !
    end function vacpol_Kn
-   
+
 
 
 !========================================================================
    function vacpol_Lk(x,k)                        result(Lk)
    !--------------------------------------------------------------------
-   ! Evaluates the LK(X) functions using the analytic functions defined  
-   ! in table 5  and equations (20) and  (21) of Fullerton and Rinker, 
-   ! Phys  Rev  A 13 (1976) 1283-1287. 
-   ! This routine is taken from RATIP and similar to ... from g 
-   ! [RCI92] which was written by F A Parpia; 
+   ! Evaluates the LK(X) functions using the analytic functions defined
+   ! in table 5  and equations (20) and  (21) of Fullerton and Rinker,
+   ! Phys  Rev  A 13 (1976) 1283-1287.
+   ! This routine is taken from RATIP and similar to ... from g
+   ! [RCI92] which was written by F A Parpia;
    ! it has been adapted in RATIP to the Fortran90/95 standard.
    !--------------------------------------------------------------------
       Use zconst
@@ -360,7 +360,7 @@
       !
       real(kind=dp), dimension(3,2), parameter :: g = reshape(source =      &
         (/   7.51198e-1_dp,  1.38889e-1_dp,  2.0886e-2_dp,                  &
-             1.37691e-1_dp, -4.16667e-1_dp, -9.7486e-2_dp                   &   
+             1.37691e-1_dp, -4.16667e-1_dp, -9.7486e-2_dp                   &
                                                            /), shape=(/3,2/))
       !
       real(kind=dp), dimension(2,2), parameter :: h = reshape(source =      &

--- a/DBSR_HF/hf_get_case.f90
+++ b/DBSR_HF/hf_get_case.f90
@@ -6,7 +6,7 @@
 !----------------------------------------------------------------------
       Use dbsr_hf
       Use df_orbitals
-      
+
       Implicit none
       Integer :: i,j
 
@@ -25,7 +25,7 @@
       ' B - S P L I N E  D I R A C - F O C K  ',&
       '======================================='
       write(scr,'(a,a)') 'name:  ',name
- 
+
       write(log,'(/a/a/a)') &
       '========================================',&
       ' B - S P L I N E  D I R A C - F O C K   ',&
@@ -34,7 +34,7 @@
 
 ! ... read input-data:
 
-      Call Read_data 
+      Call Read_data
 
 ! ... initialize Lagrange multipliers:
 
@@ -52,23 +52,23 @@
 !======================================================================
      Subroutine Check_name
 !======================================================================
-! .. read name of the case and check if name.inp exist;  
+! .. read name of the case and check if name.inp exist;
 ! .. if exist - return, otherwise check if name is a true atom symbol
-! .. and prepare file "name.inp"; 
-! .. atomic number, an=.., can be supplied instead atomic symbol 
+! .. and prepare file "name.inp";
+! .. atomic number, an=.., can be supplied instead atomic symbol
 !----------------------------------------------------------------------
      Use dbsr_hf
      Implicit none
      Real(8) :: a1,r1
 
      Call Read_name (name)
-     if(len_trim(name).ne.0) Return 
+     if(len_trim(name).ne.0) Return
 
      Call Read_aarg('atom',atom)
      Call Read_iarg('an',an)
      Call Read_aarg('ion',ion)
      Call Read_iarg('ai',ai)
- 
+
      if(len_trim(atom).gt.0) then
       Call Def_atom(an,atom,a1,r1,conf_AV,conf_LS)
      elseif(an.gt.0) then
@@ -88,8 +88,8 @@
      if(len_trim(ion).gt.0.and.an.gt.0.and.atom.ne.ion) &
         write(name,'(a,a,i3.3)')  trim(ion),'_',an
 
-     if(len_trim(name).eq.0) & 
-     Stop ' Please, indicate name of the case, e.g., atom symbol:  dbsr_hf Ne'  
+     if(len_trim(name).eq.0) &
+     Stop ' Please, indicate name of the case, e.g., atom symbol:  dbsr_hf Ne'
 
      End Subroutine Check_name
 
@@ -120,7 +120,7 @@
       Call Read_string(inp,'core',core)
       Call Read_apar(inp,'conf',configuration)
       Call Read_apar(inp,'term',term)
-      Call Read_string(inp,'varied',anit)     
+      Call Read_string(inp,'varied',anit)
 
       Call Read_rpar(inp,'scf_tol',scf_tol)
       Call Read_rpar(inp,'orb_tol',orb_tol)
@@ -141,7 +141,7 @@
       Call Read_apar(inp,'knot',knot)
 
 !-----------------------------------------------------------------------------------
-     
+
       Call Read_aarg('atom',atom)
       Call Read_iarg('an',an)
       Call Read_rarg('z',z)
@@ -151,10 +151,10 @@
       Call Read_rarg('z',z)
       Call Read_rarg('atw',atw)
       Call Read_rarg('rms',rms)
-      Call Read_aarg('core',core)      
+      Call Read_aarg('core',core)
       Call Read_aarg('conf',configuration)
       Call Read_aarg('term',term)
-      Call Read_aarg('varied',anit)     
+      Call Read_aarg('varied',anit)
 
       Call Read_rarg('scf_tol',scf_tol)
       Call Read_rarg('orb_tol',orb_tol)
@@ -212,15 +212,15 @@
       Call Def_core
 
       if(term.eq.'jj') then
-       Call Def_conf_jj 
+       Call Def_conf_jj
       elseif(term.eq.'LS') then
-       Call Def_conf_LS 
+       Call Def_conf_LS
        Call Def_conf
       else
        Call Def_conf
       end if
 
-! ... define generalized configuration: 
+! ... define generalized configuration:
 
       i = 1
       Do j=ncore+1,nwf
@@ -233,30 +233,30 @@
 
       Call Def_nit(anit)
 
-      write(log,'( /a,a)') 'ATOM    ',atom 
-      write(log,'(  a,a)') 'TERM    ',term 
+      write(log,'( /a,a)') 'ATOM    ',atom
+      write(log,'(  a,a)') 'TERM    ',term
       write(log,'(a,f5.0)')'Z    ',z
       if(LEN_TRIM(core).ne.0) &
-      write(log,'(/ a,a)') 'core:   ',trim(adjustl(core)) 
-      write(log,'(  a,a)') 'conf:   ',trim(adjustl(conf_AV)) 
+      write(log,'(/ a,a)') 'core:   ',trim(adjustl(core))
+      write(log,'(  a,a)') 'conf:   ',trim(adjustl(conf_AV))
       write(log,'(/ a,a)') 'orbitals to optimize:  ',anit
       if(LEN_TRIM(core).ne.0) &
-      write(scr,'(/a,a)') 'core:  ',trim(adjustl(core)) 
+      write(scr,'(/a,a)') 'core:  ',trim(adjustl(core))
       if(len_trim(conf_AV).gt.0) &
       write(scr,'(a,a/)') 'conf:  ', trim(adjustl(conf_AV))
 
       if(nconf.gt.1) then
       if(term.eq.'LS')  write(log,'(/a,i3,a)') 'nconf =',nconf,&
-	   '  - number of configurations to optimize, see conf-file'  
+	   '  - number of configurations to optimize, see conf-file'
       if(term.eq.'jj')  write(log,'(/a,i3,a)') 'nconf =',nconf,&
-	   '  - atomic states to optimize, see c-file'  
+	   '  - atomic states to optimize, see c-file'
 
       if(eal.eq.1)  write(log,'(a,i3,a)') 'eal   =',eal,&
-	   '  - weights of states are equal'  
+	   '  - weights of states are equal'
       if(eal.eq.5)  write(log,'(a,i3,a)') 'eal   =',eal,&
-	   '  - weights of states are statistical'  
+	   '  - weights of states are statistical'
       if(eal.eq.9)  write(log,'(a,i3,a)') 'eal   =',eal,&
-	   '  - weights of states are chosen by user'  
+	   '  - weights of states are chosen by user'
       end if
 
       write(log,'(//a/)') 'Running parameters:'
@@ -268,10 +268,10 @@
                 '- orbital tail cut-off'
       write(log,'(a,i3,T25,a)') 'max_it  = ',max_it, &
                 '- max. number of iterations'
-      write(log,'(a)') 
+      write(log,'(a)')
       if(rotate.gt.0) &
       write(log,'(a,i2,T25,a)') 'rotate  = ',rotate, &
-                '- use rotations of orbitals'  
+                '- use rotations of orbitals'
 
       Call Write_inp
 
@@ -282,14 +282,14 @@
 !======================================================================
       Subroutine Def_core
 !======================================================================
-!     This routine defines the closed shells which will be considered as 
-!     a core (from the string "core"). 
+!     This routine defines the closed shells which will be considered as
+!     a core (from the string "core").
 !     DBSR_HF has no special treatment of core orbitals, however,
 !     it is used for more compact notation of atomic configuration
-!     and for consistency with other GRASP and DBSR programs. 
+!     and for consistency with other GRASP and DBSR programs.
 !     INPUT:  string  "core"
 !     OUTPUT: ncore, e_core,n_core,k_core,l_core(i),j_core
-!                    all -> arrays (1:ncore) 
+!                    all -> arrays (1:ncore)
 !----------------------------------------------------------------------
       Use dbsr_hf
       Use atoms_par
@@ -318,7 +318,7 @@
          Stop 'Stop in def_core routine: unable to define core orbitals'
        End Select
       end if
-   
+
       Do i = 1,mcore
        read(core,*,IOSTAT=ii) e_core(1:i)
        if (ii /= 0) Exit
@@ -327,10 +327,10 @@
       Do i = 1,ncore
        e_core(i) = adjustl(e_core(i))
        Call EL_NLJK(e_core(i),n_core(i),k_core(i),l_core(i),j_core(i),ii)
-      End do 
+      End do
       core = ' '
       write(core,'(50a5)') (e_core(i),i=1,ncore)
-   
+
       End Subroutine Def_core
 
 
@@ -345,7 +345,7 @@
 
       Implicit none
       Integer :: i,j,start,i1,i2
-      Character(5), external :: Eli 
+      Character(5), external :: Eli
 
       Call Read_confs;  if(nconf.gt.0) Return
 
@@ -408,7 +408,7 @@
       Character :: line*200, EL*5
       Integer :: i,j,m, n,l,k,iset,iq,io, start, i1,i2, ii,jj,iw
       Integer, external :: Ifind_orb, ndets_jq, Ifind_position
-      Character(5), external :: Eli 
+      Character(5), external :: Eli
 
 ! ... check conf-file:
 
@@ -423,7 +423,7 @@
 
       Open(nuc,file=AF_conf)
       rewind(nuc)
-    1 read(nuc,'(a)',end=2) line  
+    1 read(nuc,'(a)',end=2) line
       if(INDEX(line,'(').eq.0) go to 1
       if(line(1:3).eq.'CSF') go to 1
       if(line(1:1).eq.'*') goto 2
@@ -492,7 +492,7 @@
 
       i = 0
       rewind(nuc)
-   10 read(nuc,'(a)',end=20) line  
+   10 read(nuc,'(a)',end=20) line
       if(INDEX(line,'(').eq.0) go to 10
       if(line(1:3).eq.'CSF') go to 10
       if(line(1:1).eq.'*') goto 20
@@ -500,7 +500,7 @@
       i = i + 1;  iw = 1
       Call Clean_a(line)
       start = 1
-      Do 
+      Do
        i1 = index(line(start:),'(')+start-1
        i2 = index(line(start:),')')+start-1
        if(i1.lt.start.or.i2.lt.start) Exit
@@ -554,7 +554,7 @@
       write(nuc,'(a)') 'Peel subshells:'
       write(nuc,'(20a5)') (ebs(i),i=ncore+1,nwf)
       write(nuc,'(a)') 'CSF(s):'
- 
+
       Do i = 1,nconf
 
       start = 1
@@ -564,7 +564,7 @@
        start = start + 9
       End do
 
-      j = len_trim(configuration) 
+      j = len_trim(configuration)
       if(j.le.72) then
        write(nuc,'(a,T73,F12.4)') configuration(1:j),weight(i)
       else
@@ -598,26 +598,26 @@
       iord = 0
 
       if(string(1:3)=='ALL' .or. string(1:3)=='all' .or. &
-         LEN_TRIM(string) == 0 ) then 
-       nit = nwf 
+         LEN_TRIM(string) == 0 ) then
+       nit = nwf
        Do i=1,nwf; iord(i)=i; End do
-      elseif(string(1:4)=='NONE' .or. string(1:4)=='none') then 
-       nit = 0 
-      elseif (INDEX(string,'n=') /= 0) then 
-       read(string(i+2:),*) n 
+      elseif(string(1:4)=='NONE' .or. string(1:4)=='none') then
+       nit = 0
+      elseif (INDEX(string,'n=') /= 0) then
+       read(string(i+2:),*) n
        k=0; Do i=1,nwf; if(nbs(i).ne.n) Cycle; k=k+1; iord(k)=i; End do
        nit = k
-      elseif (INDEX(string,'n>') /= 0) then 
-       read(string(i+2:),*) n 
+      elseif (INDEX(string,'n>') /= 0) then
+       read(string(i+2:),*) n
        k=0; Do i=1,nwf; if(nbs(i).le.n) Cycle; k=k+1; iord(k)=i; End do
        nit = k
-      elseif (INDEX(string,'=') /= 0) then 
-       i = INDEX(string,'=') 
-       read(string(i+1:),*) nit 
+      elseif (INDEX(string,'=') /= 0) then
+       i = INDEX(string,'=')
+       read(string(i+1:),*) nit
        k=0; Do i=nwf-nit+1,nwf; k=k+1; iord(k)=i; End do
       else
        start = 1; ip = 0
-       Do  
+       Do
         i = index(string(start:),',')
         if (i /= 0 .or. LEN_TRIM(string(start:)) /= 0) then
          read(string(start:),*) EL
@@ -625,13 +625,13 @@
          j = Ifind_orb(n,k,iset)
          if(j.gt.0) then; ip=ip+1; iord(ip)=j; end if
         end if
-        start = start + i 
+        start = start + i
         if(i == 0 .or.  LEN_TRIM(string(start:)) == 0) Exit
        End do
        nit = ip
       end if
 
-      Do j=1,nwf; i=iord(j) 
+      Do j=1,nwf; i=iord(j)
        if(i.eq.0) Cycle
        if(qsum(i).eq.0.d0) iord(j)=0
       End do
@@ -645,7 +645,7 @@
 !======================================================================
       Subroutine write_inp
 !======================================================================
-!     This routine prepare default input file 
+!     This routine prepare default input file
 !----------------------------------------------------------------------
       Use dbsr_hf
 
@@ -686,11 +686,11 @@
       write(inp,'(a,i3,T40,a)') 'max_it  = ',max_it, &
                 '- max. number of iterations'
       write(inp,'(a,i2,T40,a)') 'ilzero  = ',ilzero, &
-                '- initial zero B-splines' 
+                '- initial zero B-splines'
       write(inp,'(a,i2,T40,a)') 'ibzero  = ',ibzero, &
-                '- minimum zero B-splines in the end' 
+                '- minimum zero B-splines in the end'
       write(inp,'(a,i2,T40,a)') 'rotate  = ',rotate, &
-                '- use orbital rotation'  
+                '- use orbital rotation'
       write(inp,'(a,i2,T40,a)') 'debug   = ',debug,  &
                 '- additional debug output'
 
@@ -698,7 +698,7 @@
                             'can be replaced from command line as:'
       write(inp,'(/a)') 'dbsr_hf name par1=value par2=value par3=value ... '
 
-      write(inp,'(/a/)') 'Name-driven file-names and key-words for their re-definition:' 
+      write(inp,'(/a/)') 'Name-driven file-names and key-words for their re-definition:'
 
       write(inp,'(a,T15,a,T40,a)') 'name'//BF_dat, 'dat=...', '- input parameters'
       write(inp,'(a,T15,a,T40,a)') 'name'//BF_log, 'log=...', '- run output and summry'
@@ -717,25 +717,25 @@
       write(inp,'(a)') 'dbsr_hf name  -  name.inp is supposed to be created by user '
 
       write(inp,'(a)') 'dbsr_hf atom  -  choose the atom with given atomic symbol'
-     
+
       write(inp,'(a)') 'dbsr_hf an=.. -  choose the atom with atomic number an'
 
       write(inp,'(a)') 'dbsr_hf name  an=...  ion=... -  choose needed ion for given an'
 
-                           
-      write(inp,'(80("_"))')                     
+
+      write(inp,'(80("_"))')
       write(inp,'(/a/)') '! Additional information for input parameters:'
 
-      write(inp,'(a)') '! term=AV  - optimize the configuration given as conf=...' 
-      write(inp,'(a)') '!            or set of configurations given in the name.conf file'                  
-      write(inp,'(a)') '! term=LS  - optimize all jj-configurations consistent with LS ' 
-      write(inp,'(a)') '!            configuration given as conf=... or set of configurations'                  
-      write(inp,'(a)') '!            given in the name.LS file'                  
-      write(inp,'(a)') '! term=jj  - optimize specific jj atomic states given in name.c file' 
+      write(inp,'(a)') '! term=AV  - optimize the configuration given as conf=...'
+      write(inp,'(a)') '!            or set of configurations given in the name.conf file'
+      write(inp,'(a)') '! term=LS  - optimize all jj-configurations consistent with LS '
+      write(inp,'(a)') '!            configuration given as conf=... or set of configurations'
+      write(inp,'(a)') '!            given in the name.LS file'
+      write(inp,'(a)') '! term=jj  - optimize specific jj atomic states given in name.c file'
       write(inp,'(a)') '!            which is prepared by user or created from previous DBSR_HF run'
       write(inp,'(a)') '! eal      - indicates the mode for the state weights:'
-      write(inp,'(a)') '!            =1 - equally weighted' 
-      write(inp,'(a)') '!            =5 - statistically weighed, default' 
+      write(inp,'(a)') '!            =1 - equally weighted'
+      write(inp,'(a)') '!            =5 - statistically weighed, default'
       write(inp,'(a)') '!            =9 - defined by user in .conf or .c files'
       write(inp,'(a)') '!            '
       write(inp,'(a)') '! varied   - possible options -> all, none, list of nl, =last, n=..., n>...'
@@ -756,7 +756,7 @@
       write(inp,'(a)') '! out_nl=1   - additional output of name.nl with w.f. for outer electron'
       write(inp,'(a)') '! out_plot=1 - additional output in name.plot'
       write(inp,'(80("_"))')
-     
+
       rewind(inp)
 
       End Subroutine write_inp

--- a/DBSR_HF/hf_get_estimates.f90
+++ b/DBSR_HF/hf_get_estimates.f90
@@ -8,7 +8,7 @@
       Use DBS_grid
       Use DBSR_HF
       Use df_orbitals
-      
+
       Implicit none
       Real(8) :: zz,ss,s
       Real(8), external :: QUADR
@@ -24,7 +24,7 @@
       AF_inp=trim(name)//BF_inp
       Call Read_apar(inp,'inp',AF_inp)
       Call Read_aarg('inp',AF_inp)
-      
+
       if(Icheck_file(AF_inp).ne.0) then
        open(nuw,file=AF_inp,form='UNFORMATTED')
        i = INDEX(AF_inp,'.',BACK=.TRUE.)
@@ -32,7 +32,7 @@
        if(AF_inp(i:).eq.'.bsw')  Call Read_pqbs(nuw)
       end if
 
-      
+
       Allocate(nl(nwf),qnl(nwf),snl(nwf))
 
       nl=0; nnl = 0
@@ -49,15 +49,15 @@
       ss = 0.d0
       Do i = 1,nnl
        s =  max(0.d0,qnl(i)-1.d0)
-       snl(i) = ss + s         
+       snl(i) = ss + s
        ss = ss + qnl(i)
       End do
-                                                      
+
 
       Do i = 1, nbf
        j = ipointer(nnl,nl,nbs(i)*1000+lbs(i))
 
-       ss = snl(j); zz = z-ss  
+       ss = snl(j); zz = z-ss
 
        if(mbs(i) /= 0) Cycle     ! We have an initial estimate
 
@@ -67,7 +67,7 @@
         if(abs(p(j,1,i)).gt.end_tol/1000) Exit   ! ???
         mbs(i) = j - 1
        End do
-  
+
 ! ... set orthogonality constraints:
 
        Do j = 1,i-1
@@ -86,9 +86,9 @@
       End do  ! over orbitals
 
       Call Check_tails(0)
- 
+
       Call update_int(0)
-      Call Energy   
+      Call Energy
 
       End Subroutine get_estimates
 

--- a/DBSR_HF/hf_get_spline_param.f90
+++ b/DBSR_HF/hf_get_spline_param.f90
@@ -1,11 +1,11 @@
 !======================================================================
-     Subroutine get_spline_param 
+     Subroutine get_spline_param
 !======================================================================
 !    This routine gets information about the spline parameters and
 !    and set up spline knots and all relevant arrays.
 !    Program checks file AF_grid (knot.dat or name.knot)
 !    for B-spline parameters  or use default ones.
-!    The spline paremeters can also be modified from command line. 
+!    The spline paremeters can also be modified from command line.
 !----------------------------------------------------------------------
      Use dbsr_hf
      Use DBS_grid
@@ -22,22 +22,22 @@
      Call alloc_DBS_gauss
      Call def_Vnucl
      Call alloc_DF_radial(ns)
-     Call alloc_DBS_integrals(ns,ks,kmin,kmax,4)     
+     Call alloc_DBS_integrals(ns,ks,kmin,kmax,4)
 
      write(log,'(/a/)') 'B-spline parameters:'
-     write(log,'(a,i5,t25,a)')   'ns   =',ns,  '-  number of splines' 
-     write(log,'(a,i5,t25,a)')   'ks   =',ks,  '-  order  of splines' 
-     write(log,'(a,i5,t25,a)')   'ksp  =',ksp, '-  for large component' 
+     write(log,'(a,i5,t25,a)')   'ns   =',ns,  '-  number of splines'
+     write(log,'(a,i5,t25,a)')   'ks   =',ks,  '-  order  of splines'
+     write(log,'(a,i5,t25,a)')   'ksp  =',ksp, '-  for large component'
      write(log,'(a,i5,t25,a)')   'ksq  =',ksq, '-  for small component'
-     write(log,'(a,f9.3,t25,a)') 'hi   =',hi,  '-  initial point' 
-     write(log,'(a,f9.3,t25,a)') 'he   =',he,  '-  exponetial step size' 
-     write(log,'(a,f9.3,t25,a)') 'tmax =',tmax,'-  maximum radius' 
+     write(log,'(a,f9.3,t25,a)') 'hi   =',hi,  '-  initial point'
+     write(log,'(a,f9.3,t25,a)') 'he   =',he,  '-  exponetial step size'
+     write(log,'(a,f9.3,t25,a)') 'tmax =',tmax,'-  maximum radius'
 
      write(log,'(/a/)') 'Spline integrals:'
-     write(log,'(a,i5,t25,a)')   'kmin =',kmin,  '-  min. multipole index' 
-     write(log,'(a,i5,t25,a)')   'kmax =',kmax,  '-  max. multipole index' 
-     write(log,'(a,i5,t25,a)')   'ntype=',ntype, '-  number of different integrals' 
-     write(log,'(a,F10.2,t25,a)')   'memory=',memory_DBS_integrals,'-  memory required (in Mb)' 
+     write(log,'(a,i5,t25,a)')   'kmin =',kmin,  '-  min. multipole index'
+     write(log,'(a,i5,t25,a)')   'kmax =',kmax,  '-  max. multipole index'
+     write(log,'(a,i5,t25,a)')   'ntype=',ntype, '-  number of different integrals'
+     write(log,'(a,F10.2,t25,a)')   'memory=',memory_DBS_integrals,'-  memory required (in Mb)'
 
-     End Subroutine get_spline_param 
+     End Subroutine get_spline_param
 

--- a/DBSR_HF/hf_matrix.f90
+++ b/DBSR_HF/hf_matrix.f90
@@ -1,5 +1,5 @@
 !=====================================================================
-      Subroutine hf_matrix(i,hfm) 
+      Subroutine hf_matrix(i,hfm)
 !=====================================================================
 !     Set up the hf_matrix "hfm" for orbital i
 !     Call(s):  a,b - angular coeficient routines
@@ -8,7 +8,7 @@
       Use DBS_grid,    only: ns,ks,ms
       Use DBS_dhl_pq,  only: dhl
       Use df_orbitals, only: kbs,nbf,qsum,p
-      
+
       Implicit none
       Integer, intent(in) :: i
       Real(8), intent(out) :: hfm(ms,ms)
@@ -19,7 +19,7 @@
 
       Real(8) :: t1,t2
       Real(8), external :: RRTC
-    
+
       t1 = RRTC()
 
 ! ... one-electron integral contribution
@@ -31,33 +31,33 @@
 ! ... this contribution is devided on 4 parts: pppp, pqpq, qpqp, qqqq
 ! ... and added separately
 
-      Do ii=1,2; Do jj=1,2   ! pppp, pqpq, qpqp, qqqq                                              
+      Do ii=1,2; Do jj=1,2   ! pppp, pqpq, qpqp, qqqq
 
       Do k=0,kmax
-                                    
+
       Call mrk_aaaa(k,ii,jj)
 
-! ... direct contribution    
+! ... direct contribution
 
        dd = 0.d0; met=0
-       Do j = 1,nbf   
-        c = a(i,j,k); if(c.eq.0.d0) cycle; if(i.eq.j) c=c+c      
+       Do j = 1,nbf
+        c = a(i,j,k); if(c.eq.0.d0) cycle; if(i.eq.j) c=c+c
         Call density(ns,ks,d,p(1,jj,j),p(1,jj,j),'s')
         dd = dd + c*d; met=met+1
        End do
        if(met.gt.0) Call Convol(ns,ks,d,dd,1,'s','s')
-       if(met.gt.0) Call Update_hs(ms,hfm,ii,ii,ns,ks,d,'s')          
+       if(met.gt.0) Call Update_hs(ms,hfm,ii,ii,ns,ks,d,'s')
 
-! ... exchange contribution 
+! ... exchange contribution
 
        xx = 0.d0; met=0
-       Do j = 1,nbf   
+       Do j = 1,nbf
         c = b(i,j,k); if (c.eq.0.d0) cycle
         Call density(ns,ks,x,p(1,ii,j),p(1,jj,j),'x')
         xx = xx + x*c; met=met+1
        End do
        if(met.gt.0) Call Convol(ns,ks,x,xx,4,'s','s')
-       if(met.gt.0) Call Update_hs(ms,hfm,ii,jj,ns,ks,x,'x')          
+       if(met.gt.0) Call Update_hs(ms,hfm,ii,jj,ns,ks,x,'x')
 
       End do ! over k
       End do; End do ! over itype
@@ -77,7 +77,7 @@
 !======================================================================
       Integer, intent(in) :: k,ii,jj
 
-      Select Case (10*ii+jj)       
+      Select Case (10*ii+jj)
        Case(11);  Call mrk_pppp(k)   !  (. p p .)          1 1
        Case(12);  Call mrk_pqpq(k)   !  (. q p .)  jj ii   1 2
        Case(21);  Call mrk_qpqp(k)   !  (. p q .)  jj ii   2 1
@@ -89,16 +89,16 @@
 
 
 !=====================================================================
-      Subroutine hf_matrix_breit(i,hfm) 
+      Subroutine hf_matrix_breit(i,hfm)
 !=====================================================================
 !     Set up the hf_matrix "hfm" for orbital i with Breit interaction
 !-----------------------------------------------------------------------
-      Use dbsr_hf                           
-      Use rk4_data      
+      Use dbsr_hf
+      Use rk4_data
       Use DBS_grid,    only: ns,ks,ms
       Use DBS_dhl_pq,  only: dhl
       Use df_orbitals, only: kbs,nbf,qsum,p
-      
+
       Implicit none
       Integer, intent(in) :: i
       Real(8), intent(out) :: hfm(ms,ms)
@@ -116,7 +116,7 @@
 
       t1 = RRTC()
 
-      Do itype=0,1                                          
+      Do itype=0,1
       Do k=0,kmax; kk = k + 1000*itype
        if(itype.eq.0)  Call msk_ppqq(k)
        if(itype.eq.1)  Call msk_pqqp(k)
@@ -126,22 +126,22 @@
 
 !---------------------------------------------------------------------------------------------
       Select case(itype)
-       Case(0)                                                 
-        Select case(int)         
+       Case(0)
+        Select case(int)
          Case(1);     ip1=1; ip2=2; jp1=1; jp2=2            !  I(ip1,jp1;ip2,jp1)   ( i . i .)
          Case(2);     ip1=1; ip2=2; jp1=1; jp2=2            !  I(jp1,ip1;jp2,ip2)   ( . i . i)
          Case(3);     ip1=1; ip2=2; jp1=2; jp2=1            !  I(ip1,jp2;jp1,ip2)   ( i . . i)
          Case(4);     ip1=2; ip2=1; jp1=1; jp2=2            !  I(jp1,ip2;ip1,jp2)   ( . i i .)
-        End Select                              
-       Case(1)               
-        Select case(int)                        
+        End Select
+       Case(1)
+        Select case(int)
          Case(1);     ip1=1; ip2=2; jp1=2; jp2=1            !  I(ip1,jp1;ip2,jp2)   ( i . i .)
          Case(2);     ip1=2; ip2=1; jp1=1; jp2=2            !  I(jp1,ip1;jp2,ip2)   ( . i . i)
          Case(3);     ip1=1; ip2=1; jp1=2; jp2=2            !  I(ip1,jp2;jp1,ip2)   ( i . . i)
          Case(4);     ip1=2; ip2=2; jp1=1; jp2=1            !  I(jp1,ip2;ip1,jp2)   ( . i i .)
-        End Select                                 
-      End Select                                   
-!----------------------------------------------------------------------------------------------                                                   
+        End Select
+      End Select
+!----------------------------------------------------------------------------------------------
 
       xx = 0.d0; met=0
       Do ik = 1,nrk;  if(kk.ne.kr1(ik)) Cycle
@@ -152,12 +152,12 @@
        end if
        if(jnt.ne.int) Cycle
 
-       Call Density(ns,ks,x,p(1,jp1,j),p(1,jp2,j),sym)   
+       Call Density(ns,ks,x,p(1,jp1,j),p(1,jp2,j),sym)
        xx = xx + crk(ik)*x; met=met+1
       End do
 
       if(met.gt.0) Call Convol_sk(ns,ks,x,xx,int,sym,sym)
-      if(met.gt.0) Call Update_hs(ms,hfm,ip1,ip2,ns,ks,x,sym)          
+      if(met.gt.0) Call Update_hs(ms,hfm,ip1,ip2,ns,ks,x,sym)
 
       End do ! over int
       End do; End do ! over k and itype

--- a/DBSR_HF/hf_orthogonality.f90
+++ b/DBSR_HF/hf_orthogonality.f90
@@ -3,7 +3,7 @@
 !==================================================================
 ! ... Redefine the matrix to project out the vector v so that
 ! ... eigenvalues of  (H' - lamda S)x = 0 are orthogonal to v.
-!              H' =>  (1 - Bvv^T ) H (1 - vv^TB) 
+!              H' =>  (1 - Bvv^T ) H (1 - vv^TB)
 !------------------------------------------------------------------
       Use DBS_grid,  only: ns,ms
       Use DBS_gauss, only: fppqq
@@ -16,11 +16,11 @@
 
       ! ..  w = B v
       w = MATMUL(fppqq,v)
-       
+
       ! .. c = 1 - Bvv^T = 1 - wv^T
       Do i=1,ms; Do j=1,ms
         c(i,j)=-w(i)*v(j); if(i.eq.j) c(i,j)=c(i,j) + 1.d0
-      End do; End do        
+      End do; End do
 
       hfm = MATMUL(c,hfm)
       c   = TRANSPOSE(c)

--- a/DBSR_HF/hf_plot_bsw.f90
+++ b/DBSR_HF/hf_plot_bsw.f90
@@ -1,35 +1,35 @@
 !======================================================================
       Subroutine plot_bsw
 !======================================================================
-! ... Computes and tabular the radial orbitals in all gausian points, 
+! ... Computes and tabular the radial orbitals in all gausian points,
 ! ... plus border values, for further plots
 ! ... at small r,  P = P0 * r^gamma (1 + r ...)
 !----------------------------------------------------------------------
       Use zconst,      only: c_au
       Use DBS_nuclear, only: nuclear
       Use DBS_grid
-      Use DBS_gauss 
+      Use DBS_gauss
       Use df_orbitals
       Use dbsr_hf
- 
+
       Implicit none
       Real(8) :: yp(nv*ks+2,nbf),yq(nv*ks+2,nbf),r(nv*ks+2)
       Integer :: i,j,io,i1,i2,m,nr
       Character(6) :: pel(nbf), qel(nbf)
       Real(8) :: P0, gamma
- 
+
       if(out_w.eq.0.and.out_plot.eq.0) Return
-      AF_plt = trim(name)//BF_plt   
+      AF_plt = trim(name)//BF_plt
       Call Read_ipar(inp,'plot',AF_plt)
       Call Read_iarg('plot',AF_plt)
       open(nup,file=AF_plt)
- 
+
 ! ... radial points for output:
 
       m=1; r(1)=t(1)
       Do i=1,nv; Do j=1,ks; m=m+1; R(m)=gr(i,j); End do; End do
       m=m+1; R(m)=t(ns+1)
- 
+
       yp = 0.d0
       yq = 0.d0
       Do io=1,nbf
@@ -38,17 +38,17 @@
        Call Bvalue_bm(ksq,p(1,2,io),yq(1,io),qbsp)
        pel(io)='p'//ebs(io); Call Clean_a(pel(io))
        qel(io)='q'//ebs(io); Call Clean_a(qel(io))
- 
+
        gamma = lbs(io) + 1
        if(nuclear.eq.'point') gamma = sqrt (kbs(io)**2 - (z/c_au)**2)
        P0 = 0.d0
-       Do i = 1,ksp; j = i + 1 
+       Do i = 1,ksp; j = i + 1
         P0 = P0 + yp(j,io)/r(j)**gamma
        End do
        P0 = P0 / ksp; yp(1,io) = P0
       ! or simply ???
        yp(1,io) = yp(2,io)/r(2)**gamma
-      End do 
+      End do
 
       if(out_plot.gt.0) then
       rewind(nup)
@@ -70,22 +70,22 @@
       Use zconst,      only: c_au
       Use DBS_nuclear, only: nuclear
       Use DBS_grid
-      Use DBS_gauss 
+      Use DBS_gauss
       Use df_orbitals
       Use dbsr_hf
- 
+
       Implicit none
-      Integer, parameter :: ng = 590  ! max. number of points in GRASP 
+      Integer, parameter :: ng = 590  ! max. number of points in GRASP
       Real(8) :: yp(ng),yq(ng),r(ng)
       Real(8) :: P0, gamma, r_max, RNT,HNT
       Integer :: i,j, io,m,np,nr
-      Real(8), external :: bvalu2 
-      
+      Real(8), external :: bvalu2
+
       if(out_w.eq.0) Return
 
 ! ... radial points for output (updated 2022, Jon Grumer):
 
-      if(nuclear.eq.'point') then 
+      if(nuclear.eq.'point') then
        RNT = EXP (-65.0d0/16.0d0) / z
        HNT = 0.5d0**4
        np  = min(220,ng)
@@ -110,7 +110,7 @@
 
 ! ... file:
 
-      AF_rwf = trim(name)//BF_rwf   
+      AF_rwf = trim(name)//BF_rwf
       Call Read_ipar(inp,'w',AF_rwf)
       Call Read_iarg('w',AF_rwf)
       Open(nuw,file=AF_rwf,form='UNFORMATTED')
@@ -136,10 +136,10 @@
        P0 = yp(2)/r(2)**gamma
 
        write(nuw) nbs(io),kbs(io),e(io,io),nr
-       write(nuw) P0,yp(1:nr),yq(1:nr)  
+       write(nuw) P0,yp(1:nr),yq(1:nr)
        write(nuw) r(1:nr)
 
       End do
-  
+
       End Subroutine GRASP_wfn
 

--- a/DBSR_HF/hf_read_GRASP.f90
+++ b/DBSR_HF/hf_read_GRASP.f90
@@ -1,8 +1,8 @@
 !======================================================================
       Subroutine Read_Grasp(nu)
 !======================================================================
-!     Generation double (p,q) B-spline representation for orbitals 
-!     given in GRASP package format, w-files 
+!     Generation double (p,q) B-spline representation for orbitals
+!     given in GRASP package format, w-files
 !----------------------------------------------------------------------
       Use DBS_grid
       Use DBS_gauss
@@ -11,7 +11,7 @@
 
       Implicit none
 
-      Real(8), allocatable :: R(:),PG(:),QG(:)     
+      Real(8), allocatable :: R(:),PG(:),QG(:)
       Real(8), allocatable :: b3(:),c3(:),d3(:),b4(:),c4(:),d4(:)
       Real(8) :: pr(nv,ks),qr(nv,ks),a(ns,ns),Pcoef(ns),Qcoef(ns)
       Character(6) string
@@ -33,7 +33,7 @@
       if(allocated(R)) Deallocate(R,PG,QG)
       Allocate(R(npts),PG(npts),QG(npts))
       READ(nu) p0,PG,QG
-      READ(nu) R 
+      READ(nu) R
 
 ! ... check if we need this orbital:
 
@@ -67,8 +67,8 @@
 
       pr = 0.d0; qr = 0.d0
       Do i=1,nv; Do j=1,ks
-       if(gr(i,j).lt.R(np)) pr(i,j)=SEVAL(np,gr(i,j),R,PG,b3,c3,d3)*grw(i,j)  
-       if(gr(i,j).lt.R(nq)) qr(i,j)=SEVAL(nq,gr(i,j),R,QG,b4,c4,d4)*grw(i,j)  
+       if(gr(i,j).lt.R(np)) pr(i,j)=SEVAL(np,gr(i,j),R,PG,b3,c3,d3)*grw(i,j)
+       if(gr(i,j).lt.R(nq)) qr(i,j)=SEVAL(nq,gr(i,j),R,QG,b4,c4,d4)*grw(i,j)
       End do; End do
 
 ! ... form the vector of inner products of the radial function and the
@@ -85,7 +85,7 @@
       End do; End do
 
 ! ... solve the system of equations for coef
-   
+
       a(1:nsp-1,1:nsp-1)=fpbs(2:nsp,2:nsp)
       Call gaussj (a,nsp-1,ns,Pcoef(2),1,ns)
       Pcoef(1)=0.d0
@@ -97,8 +97,8 @@
       p(:,1,ii) = Pcoef
       p(:,2,ii) = Qcoef
       Call Check_tails(ii)
-     
-! ... check the normalization 
+
+! ... check the normalization
 
       PN = sqrt(QUADR(p(1,1,ii),p(1,1,ii),0))
       p(:,:,ii)=p(:,:,ii)/PN
@@ -107,7 +107,7 @@
 
       pm = 0.d0
       Do j=2,np
-       PP = bvalu2(tp,p(1,1,ii),nsp,ksp,R(j),0) 
+       PP = bvalu2(tp,p(1,1,ii),nsp,ksp,R(j),0)
        d = abs(PP-PG(j));  if(d.gt.pm) pm = d
       End do
 

--- a/DBSR_HF/hf_read_pqbs.f90
+++ b/DBSR_HF/hf_read_pqbs.f90
@@ -12,11 +12,11 @@
       Integer, intent(in) :: nu
       Integer :: i,j,k,ip,iq,ka,l,n,m,itype,nsw,ksw,mw,kp,kq
       Character(5) :: elw
-      Integer, external :: Ifind_orb 
+      Integer, external :: Ifind_orb
       Real(8), allocatable :: tw(:),pw(:),qw(:)
       Real(8) :: S
 
-! ... read the written B-spline grid and check if it matches 
+! ... read the written B-spline grid and check if it matches
 
       rewind(nu)
       read(nu) itype,nsw,ksw
@@ -32,26 +32,26 @@
       if(ksq.ne.kq) k=0
       Do i=1,ns+ks; if(k.eq.0) Exit
        if(abs(t(i)-tw(i)).lt.1.d-12) Cycle; k=0; Exit
-      End do    
+      End do
 
-! ... read radial functions and converte them if necessary 
+! ... read radial functions and converte them if necessary
 
     1 read(nu,end=2) elw,mw, S
       pw=0.d0; read(nu) pw(1:mw)
       qw=0.d0; read(nu) qw(1:mw)
       Call EL_NLJK(elw,n,ka,l,j,i)
       m = Ifind_orb(n,ka,i)
-      if(m.eq.0) go to 1    ! skip that orbital 
+      if(m.eq.0) go to 1    ! skip that orbital
       e(m,m) = S
       if(k.eq.1) then
        mbs(m)=mw
-       p(:,1,m) = pw 
-       p(:,2,m) = qw 
+       p(:,1,m) = pw
+       p(:,2,m) = qw
        write(log,'(a,a,a)') ebs(m),' - read from file ', trim(AF_inp)
-      else                 
+      else
        Call Convert_pq(nsw-ip,kp,tw(1+ip),pw,nsp,ksp,p(1,1,m),pbsp,fpbs,1,0)
        Call Convert_pq(nsw-iq,kq,tw(1+iq),qw,nsq,ksq,p(1,2,m),qbsp,fqbs,1,0)
-       mbs(m) = nsp-1                                  
+       mbs(m) = nsp-1
        write(log,'(a,a,a,a)') ebs(m),' - read from file ', trim(AF_inp),' and converted'
       end if
 

--- a/DBSR_HF/hf_rk.f90
+++ b/DBSR_HF/hf_rk.f90
@@ -1,12 +1,12 @@
 !======================================================================
-      Real(8) Function hf_rk (i1,j1,i2,j2,k) 
+      Real(8) Function hf_rk (i1,j1,i2,j2,k)
 !======================================================================
 !     Returns  hf_rk (i1, j1; i2, j2), base on the assembling two-electron
 !     B-spline integrals (see module DBS_integral)
 !----------------------------------------------------------------------
       Use DBS_grid,      only: ns,ks
       Use DF_orbitals,   only: p
-  
+
       Implicit none
       Integer, intent(in) :: i1,j1,i2,j2,k
       Real(8) :: dens1(ns,ks),dens2(ns,ks),dens3(ns,ks),dens4(ns,ks), &
@@ -23,7 +23,7 @@
       Call mrk_pppp(k)
       Call convol  (ns,ks,conv,dens1,2,'s','s')
       hf_rk = hf_rk + SUM_AmB(ns,ks,conv,dens2,'s')
-  
+
       Call mrk_qqqq(k)
       Call convol  (ns,ks,conv,dens3,2,'s','s')
       hf_rk = hf_rk + SUM_AmB(ns,ks,conv,dens4,'s')
@@ -45,9 +45,9 @@
 !     Returns  Fk (i, j) base on the assembling two-electron
 !     B-spline integrals (see module DBS_integral)
 !----------------------------------------------------------------------
-      Use DBS_grid,      only: ns,ks        
-      Use df_orbitals,   only: p 
-  
+      Use DBS_grid,      only: ns,ks
+      Use df_orbitals,   only: p
+
       Implicit none
       Integer, intent(in) :: i,j,k
       Real(8) :: ppi(ns,ks),qqi(ns,ks),ppj(ns,ks),qqj(ns,ks), &
@@ -64,7 +64,7 @@
       Call mrk_pppp(k)
       Call convol (ns,ks,pppp,ppi,2,'s','s')
       S = S + SUM_AmB(ns,ks,pppp,ppj,'s')
-  
+
       Call mrk_qqqq(k)
       Call convol (ns,ks,qqqq,qqi,2,'s','s')
       S = S + SUM_AmB(ns,ks,qqqq,qqj,'s')
@@ -85,9 +85,9 @@
 !======================================================================
 !     Exchange integral:  Rk(i,j;j,i)
 !----------------------------------------------------------------------
-      Use DBS_grid,      only: ns,ks                      
-      Use df_orbitals,   only: p 
-  
+      Use DBS_grid,      only: ns,ks
+      Use df_orbitals,   only: p
+
       Implicit none
       Integer, intent(in) :: i,j,k
       Real(8) :: pp(ns,ks),qq(ns,ks),conv(ns,ks)
@@ -101,7 +101,7 @@
       Call mrk_pppp(k)
       Call convol (ns,ks,conv,pp,2,'s','s')
       S = S + SUM_AmB(ns,ks,conv,pp,'s')
-  
+
       Call mrk_qqqq(k)
       Call convol (ns,ks,conv,qq,2,'s','s')
       S = S + SUM_AmB(ns,ks,conv,qq,'s')

--- a/DBSR_HF/hf_rotate.f90
+++ b/DBSR_HF/hf_rotate.f90
@@ -7,7 +7,7 @@
       Use DBS_grid
       Use DBSR_hf
       Use df_orbitals, l=>lbs
-      
+
       Implicit none
       Integer, intent(in) :: i,j
       Integer :: m,k
@@ -15,27 +15,27 @@
        Hii,Hij,Hjj, Fkii,Fkij,Fkjj,Gkij, RKij,RKji, FKim,Fkjm, GKim,Gkjm
       Real(8), external :: Vp_dhl, a, b, rk
 
-      if(i.ge.j) Return 
+      if(i.ge.j) Return
       if(kbs(i).ne.kbs(j)) Return
       if(iord(i).eq.0) Return
       if(iord(j).eq.0) Return
       if(clsd(i).and.clsd(j)) Return
-      
+
       Hii = Vp_dhl(kbs(i),p(1,1,i),kbs(i),p(1,1,i))
       Hij = Vp_dhl(kbs(i),p(1,1,i),kbs(j),p(1,1,j))
       Hjj = Vp_dhl(kbs(j),p(1,1,j),kbs(j),p(1,1,j))
       G   = 2.d0*(qsum(j)-qsum(i))*Hij
       dG  = (qsum(i)-qsum(j))*(Hjj-Hii)
-      
+
       Do k= 0,2*min0(l(i),l(j)),2
        RKij = rk(p(1,1,i),p(1,1,i),p(1,1,i),p(1,1,j),k)
        RKji = rk(p(1,1,i),p(1,1,j),p(1,1,j),p(1,1,j),k)
        G = G + 2.d0 * (a(i,j,k)+b(i,j,k)-2*a(i,i,k)) * RKij
        G = G - 2.d0 * (a(i,j,k)+b(i,j,k)-2*a(j,j,k)) * RKji
-       FKii = rk(p(1,1,i),p(1,1,i),p(1,1,i),p(1,1,i),k) 
-       FKij = rk(p(1,1,i),p(1,1,j),p(1,1,i),p(1,1,j),k) 
-       FKjj = rk(p(1,1,j),p(1,1,j),p(1,1,j),p(1,1,j),k) 
-       GKij = rk(p(1,1,i),p(1,1,j),p(1,1,j),p(1,1,i),k) 
+       FKii = rk(p(1,1,i),p(1,1,i),p(1,1,i),p(1,1,i),k)
+       FKij = rk(p(1,1,i),p(1,1,j),p(1,1,i),p(1,1,j),k)
+       FKjj = rk(p(1,1,j),p(1,1,j),p(1,1,j),p(1,1,j),k)
+       GKij = rk(p(1,1,i),p(1,1,j),p(1,1,j),p(1,1,i),k)
        dG = dG + 2*a(i,i,k)*(FKij-FKii+2*GKij) + 2*a(j,j,k)*(FKij-FKjj+2*GKij)
        dG = dG + (a(i,j,k)+b(i,j,k)) * (FKii+Fkjj-2*FKij-4*GKij)
       End do
@@ -45,26 +45,26 @@
        Do  k = 0,2*min0(l(i),l(j)),2
         if (a(i,m,k) == a(j,m,k)) Cycle
         g  = g + 2.d0*(a(j,m,k)-a(i,m,k))*rk(p(1,1,i),p(1,1,m),p(1,1,j),p(1,1,m),k)
-        FKim = rk(p(1,1,i),p(1,1,m),p(1,1,i),p(1,1,m),k) 
-        FKjm = rk(p(1,1,j),p(1,1,m),p(1,1,j),p(1,1,m),k) 
+        FKim = rk(p(1,1,i),p(1,1,m),p(1,1,i),p(1,1,m),k)
+        FKjm = rk(p(1,1,j),p(1,1,m),p(1,1,j),p(1,1,m),k)
         dg =dg + (a(j,m,k)-a(i,m,k))*(FKim-FKjm)
        End do
        Do k = abs(l(i)-l(m)),l(i)+l(m),2
         if (b(i,m,k) == b(j,m,k)) Cycle
         g  = g + 2.d0*(b(j,m,k)-b(i,m,k))*rk(p(1,1,i),p(1,1,m),p(1,1,m),p(1,1,j),k)
-        GKim = rk(p(1,1,i),p(1,1,m),p(1,1,m),p(1,1,i),k) 
-        GKjm = rk(p(1,1,j),p(1,1,m),p(1,1,m),p(1,1,j),k) 
+        GKim = rk(p(1,1,i),p(1,1,m),p(1,1,m),p(1,1,i),k)
+        GKjm = rk(p(1,1,j),p(1,1,m),p(1,1,m),p(1,1,j),k)
         dg =dg + (b(j,m,k)-b(i,m,k))*(GKim-GKjm)
        End do
       End do
 
       if ( abs(g) < 1.d-12 .and. abs(dg) < 1.d-12 ) then
-      
+
        e(i,j) = 0.d0
        e(j,i) = 0.d0
-      
+
       else
-      
+
        eps = -g / (2*dg)
        dn = 1.d0/sqrt(1+eps*eps)
        v = (p(:,1,i)-eps*p(:,1,j))*dn
@@ -75,20 +75,20 @@
        w = (p(:,2,j)+eps*p(:,2,i))*dn
        p(:,2,i) = v
        p(:,2,j) = w
-      
+
        Call Check_tails(i)
        Call Check_tails(j)
-      
+
        if(debug.gt.0)  write(log,'(/a,a,a,a,3f16.8/)') &
         'Rotate ',ebs(i),ebs(j),' eps,g,dg = ', eps,g,dg
-      
+
        e(i,j) = 1.d0
        e(j,i) = 1.d0
-      
+
       end if
-      
+
       End Subroutine rotate_ij
-       
-           
-   
- 
+
+
+
+

--- a/DBSR_HF/hf_sk.f90
+++ b/DBSR_HF/hf_sk.f90
@@ -6,7 +6,7 @@
 !----------------------------------------------------------------------
       Use DBS_grid,      only: ns,ks
       Use DF_orbitals,   only: p
-  
+
       Implicit none
       Integer, intent(in) :: i1,j1,i2,j2,k
       Real(8) :: di(ns,ns),dj(ns,ns),dc(ns,ns)
@@ -30,7 +30,7 @@
 !----------------------------------------------------------------------
       Use DBS_grid,     only: ns,ks
       Use DF_orbitals,  only: p
-  
+
       Implicit none
       Integer, intent(in) :: i1,j1,i2,j2,k
       Real(8) :: di(ns,ns),dj(ns,ns),dc(ns,ns)

--- a/DBSR_HF/hf_solve_HF.f90
+++ b/DBSR_HF/hf_solve_HF.f90
@@ -1,7 +1,7 @@
 !=====================================================================
       Subroutine solve_HF
 !=====================================================================
-!     Solve the DF equations in turns 
+!     Solve the DF equations in turns
 !---------------------------------------------------------------------
       Use DBS_grid
       Use dbsr_hf
@@ -14,7 +14,7 @@
 
       Real(8) :: t1,t2,t3,t4 , S1,S2
       Real(8), external :: RRTC
-    
+
       t1 = RRTC()
 
       et = etotal
@@ -36,7 +36,7 @@
 
         ! .. diagonalize the hf matrix
 
-        Call hf_eiv(i,hfm,v) 
+        Call hf_eiv(i,hfm,v)
 
 
         dpm(i)=maxval(abs(p(1:ns,1,i)-v(1:ns)))/maxval(abs(p(:,1,i)))
@@ -61,16 +61,16 @@
         ! .. remove tail zero
 
         if(debug.gt.0) then
-         Do j = 1,nwf 
-          if(i.eq.j) Cycle 
-          if(e(i,j) < 1.d-10) Cycle      
+         Do j = 1,nwf
+          if(i.eq.j) Cycle
+          if(e(i,j) < 1.d-10) Cycle
           if(kbs(i).ne.kbs(j)) Cycle
           write(log,'(a,a,a,f16.8)') &
            'Orthogonality ',ebs(i),ebs(j),QUADR(p(1,1,i),p(1,1,j),0)
          End do
         end if
 
-       End do ! over functions 
+       End do ! over functions
 
        Call Energy
        write(log,'(/a,F16.8)') 'Etotal = ',etotal
@@ -83,7 +83,7 @@
        write(log,'(A,T25,1PD10.2)') 'Energy difference     ', scf_diff
        write(scr,'(a,F20.12,i5,1P2E10.2)') &
         'etotal,it,E_diff,orb_diff = ',etotal,it,scf_diff,orb_diff
-       
+
        Call Boundary_conditions
 
        if ( orb_diff < orb_tol .and. scf_diff  < scf_tol ) Exit
@@ -91,11 +91,11 @@
       End do ! over iterations
 
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'time_eiv:',time_hf_eiv,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'time_eiv:',time_hf_eiv,'  sec'
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'time_mat:',time_hf_matrix,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'time_mat:',time_hf_matrix,'  sec'
       if(debug.gt.0) &
-      write(scr,'(a,T30,f10.2,a)') 'time_int:',time_update_int,'  sec' 
+      write(scr,'(a,T30,f10.2,a)') 'time_int:',time_update_int,'  sec'
 
       End Subroutine solve_HF
 
@@ -104,7 +104,7 @@
       Subroutine hf_eiv(i,hfm,v)
 !==================================================================
 !     Find the eigenvector v of hfm for the "positive-eneregy"
-!     eigenvalue m=n-l. Each orthogonality condition to the lower 
+!     eigenvalue m=n-l. Each orthogonality condition to the lower
 !     state reduces m - m - 1.  We supposed that nl orbitals are
 !     ordered to their n-values.
 !------------------------------------------------------------------
@@ -123,15 +123,15 @@
 
       Real(8) :: t1,t2
       Real(8), external :: RRTC
-    
+
       t1 = RRTC()
 
 ! ... apply orthogonality conditions for orbitals
 
       m = nbs(i)-lbs(i)
-      Do j = 1,nwf 
-       if(i.eq.j) Cycle 
-       if(e(i,j) < 1.d-10) Cycle     
+      Do j = 1,nwf
+       if(i.eq.j) Cycle
+       if(e(i,j) < 1.d-10) Cycle
        if(kbs(i).ne.kbs(j)) Cycle
        Call orthogonality(hfm,p(1,1,j))
        if(j.lt.i) m = m - 1
@@ -147,10 +147,10 @@
        k=0
        Do jp=1,ms
         if(iprm(jp,i).eq.0) Cycle
-        k=k+1; a(k)=hfm(jp,j); s(k)=fppqq(jp,j)  
+        k=k+1; a(k)=hfm(jp,j); s(k)=fppqq(jp,j)
        End do
        aa(1:k,kk)=a(1:k); ss(1:k,kk)=s(1:k)
-      End do 
+      End do
 
 ! ... evaluates the eigenvalues and eigenvectors (LAPACK routine):
 
@@ -166,15 +166,15 @@
 
 ! ... save all solutions if nl > 0:
 
-      if(out_nl.gt.0.and.i.eq.nwf) then 
-       nsol_nl = kk - mm + 1 
+      if(out_nl.gt.0.and.i.eq.nwf) then
+       nsol_nl = kk - mm + 1
        if(.not.allocated(p_nl)) Allocate(p_nl(ms,nsol_nl),e_nl(nsol_nl))
        p_nl = 0.d0; e_nl=0.d0
        Do m=mm,kk
         a(1:ms) = aa(1:ms,m);  v=0.d0; k=0
         Do j=1,ms
          if(iprm(j,i).eq.0) Cycle; k=k+1; v(j)=a(k)
-        End do 
+        End do
 
         if (v(ks) < 0.d0) v = -v
 
@@ -188,7 +188,7 @@
       a(1:ms) = aa(1:ms,mm);  v=0.d0; k=0
       Do j=1,ms
        if(iprm(j,i).eq.0) Cycle; k=k+1; v(j)=a(k)
-      End do 
+      End do
 
       ipos=maxloc(abs(v))
       if(v(ipos(1)).lt.0.d0) v=-v

--- a/DBSR_HF/hf_state_energies.f90
+++ b/DBSR_HF/hf_state_energies.f90
@@ -1,13 +1,13 @@
-!====================================================================== 
+!======================================================================
       Subroutine State_energies
-!====================================================================== 
+!======================================================================
 ! ... calculation and output of the state energies obtained in CI procedure
 !----------------------------------------------------------------------
       Use DBSR_hf
       Use DF_orbitals
       Use hf_energy
       Use rk4_data
-      Use DBS_grid, only: ns,ks                      
+      Use DBS_grid, only: ns,ks
 
       Implicit none
 
@@ -40,7 +40,7 @@
       inquire(file=AF_cfg,number=i)
       if(i.gt.0) Close(i)
       open(nuc,file=AF_cfg)
-      rewind(nuc)      
+      rewind(nuc)
 
       nconf = Jdef_ncfg(nuc)
 
@@ -58,10 +58,10 @@
       inquire(file=AF_cfg,number=i)
       if(i.gt.0) Close(i)
       open(nuc,file=AF_cfg)
-      rewind(nuc)      
+      rewind(nuc)
 
       ic = 0;  njbl = 0; JTc = 0
-      Do 
+      Do
        read(nuc,'(a)') CONFIG
        if(CONFIG(6:6).ne.'(') Cycle
        read(nuc,'(a)') SHELLJ
@@ -86,14 +86,14 @@
         else
          njbl = njbl + 1; JTc(njbl)=ic
         end if
-       end if 
+       end if
        iset = 0
        Call labelc_jj (mlab,Labels(ic),iset, &
             no,nnc(1,ic),lnc(1,ic),knc(1,ic),jnc(1,ic),inc(1,ic),iqc(1,ic), &
             Jshellc(1,ic),Vshellc(1,ic),Jintrac(1,ic) )
-       ii=LEN_TRIM(Labels(ic)); if(ii.gt.ilabel) ilabel=ii 
+       ii=LEN_TRIM(Labels(ic)); if(ii.gt.ilabel) ilabel=ii
 
-       ! ... add core:  
+       ! ... add core:
        if(ncore.gt.0) then
         noc(ic) = no + ncore
         nnc(ncore+1:ncore+no,ic) =  nnc(1:no,ic)
@@ -111,8 +111,8 @@
         Jshellc(ncore+1:ncore+no,ic) =  Jshellc(1:no,ic)
         Vshellc(ncore+1:ncore+no,ic) =  Vshellc(1:no,ic)
         Jintrac(ncore+1:ncore+no,ic) =  Jintrac(1:no,ic)
-        Jshellc(1:ncore,ic)=0 
-        Vshellc(1:ncore,ic)=0 
+        Jshellc(1:ncore,ic)=0
+        Vshellc(1:ncore,ic)=0
         Jintrac(1:ncore,ic)=0
        end if
 
@@ -137,13 +137,13 @@
                           noc(jc),nnc(1,jc),lnc(1,jc),jnc(1,jc),iqc(1,jc), &
                           Jshellc(1,jc),Vshellc(1,jc),Jintrac(1,jc),  &
                           mcoef,ncoef,icoefs,coefs)
-       
+
        if(ncoef.eq.0.d0) Cycle;  ij = ic*ibi+jc
-       
+
        Do i = 1,ncoef; if(abs(coefs(i)).lt.eps_c) Cycle; met=2
 
         k = icoefs(1,i)
-        if(k.lt.0) then; met=1; k=0; end if         
+        if(k.lt.0) then; met=1; k=0; end if
         i1=icoefs(2,i); i1=ipc(i1,ic); k1=kbs(i1)
         i2=icoefs(3,i); i2=ipc(i2,ic); k2=kbs(i2)
         i3=icoefs(4,i); i3=ipc(i3,jc); k3=kbs(i3)
@@ -151,20 +151,20 @@
 
         Call Add_rk4_data(met*ibi+k,i1*ibi+i2,i3*ibi+i4,ij,coefs(i))
 
-        if(met.ne.2.or.mbreit.eq.0) Cycle 
+        if(met.ne.2.or.mbreit.eq.0) Cycle
 
         Do v = k-1,k+1
          if(SMU(k1,k2,k3,k4,k,v,S).eq.0.d0) Cycle
          S = S * coefs(i);  met = 3*ibi+v
-         Call Add_rk4_data(met,i1*ibi+i2,i3*ibi+i4,ij,S(1)) 
-         Call Add_rk4_data(met,i2*ibi+i1,i4*ibi+i3,ij,S(2)) 
-         Call Add_rk4_data(met,i3*ibi+i4,i1*ibi+i2,ij,S(3)) 
-         Call Add_rk4_data(met,i4*ibi+i3,i2*ibi+i1,ij,S(4)) 
-         Call Add_rk4_data(met,i1*ibi+i4,i3*ibi+i2,ij,S(5)) 
-         Call Add_rk4_data(met,i4*ibi+i1,i2*ibi+i3,ij,S(6)) 
-         Call Add_rk4_data(met,i3*ibi+i2,i1*ibi+i4,ij,S(7)) 
-         Call Add_rk4_data(met,i2*ibi+i3,i4*ibi+i1,ij,S(8)) 
-        End do                 
+         Call Add_rk4_data(met,i1*ibi+i2,i3*ibi+i4,ij,S(1))
+         Call Add_rk4_data(met,i2*ibi+i1,i4*ibi+i3,ij,S(2))
+         Call Add_rk4_data(met,i3*ibi+i4,i1*ibi+i2,ij,S(3))
+         Call Add_rk4_data(met,i4*ibi+i3,i2*ibi+i1,ij,S(4))
+         Call Add_rk4_data(met,i1*ibi+i4,i3*ibi+i2,ij,S(5))
+         Call Add_rk4_data(met,i4*ibi+i1,i2*ibi+i3,ij,S(6))
+         Call Add_rk4_data(met,i3*ibi+i2,i1*ibi+i4,ij,S(7))
+         Call Add_rk4_data(met,i2*ibi+i3,i4*ibi+i1,ij,S(8))
+        End do
        End do         ! over coeffs, i
       End do; End do ! over states ic,jc
 
@@ -174,10 +174,10 @@
       HC = 0.d0; HB = 0.d0; H_self = 0.d0; H_vacpol = 0.d0
 
       ! one-electron integrals
- 
+
       Do i=1,nrk;  met=kr1(i)/ibi; if(met.ne.1) Cycle
-       i1 = kr2(i)/ibi;  i2 = kr3(i)/ibi  
-       ic = kr4(i)/ibi;  jc = mod(kr4(i),ibi)  
+       i1 = kr2(i)/ibi;  i2 = kr3(i)/ibi
+       ic = kr4(i)/ibi;  jc = mod(kr4(i),ibi)
        if(i1.eq.i2) then
         HC(ic,jc) = HC(ic,jc) + crk(i)*ValueI(i1)
        else
@@ -188,9 +188,9 @@
       ! two-electron Coulomb integrals: B-spline integrals should be allocated !!!
 
       Do i=1,nrk;  met=kr1(i)/ibi; if(met.ne.2) Cycle; k = mod(kr1(i),ibi)
-       i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi) 
-       i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi) 
-       ic = kr4(i)/ibi; jc = mod(kr4(i),ibi)  
+       i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi)
+       i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi)
+       ic = kr4(i)/ibi; jc = mod(kr4(i),ibi)
 
        if(mod(k+lbs(i1)+lbs(i3),2).ne.0) Cycle
        if(mod(k+lbs(i2)+lbs(i4),2).ne.0) Cycle
@@ -203,25 +203,25 @@
          HC(ic,jc) = HC(ic,jc) + crk(i)*Value(i3,i4,k)
        else                                                   ! Rk integrals
          HC(ic,jc) = HC(ic,jc) + crk(i)*hf_rk(i1,i2,i3,i4,k)
-       end if   
+       end if
       End do
 
-      ! two-electron Breit integrals: 
+      ! two-electron Breit integrals:
 
       if(mbreit.gt.0) then
 
        C = 0.d0
        Call Alloc_DBS_integrals(ns,2*ks-1,0,kmax+1,1)
        Do i=1,nrk;  met=kr1(i)/ibi; if(met.ne.3) Cycle; k = mod(kr1(i),ibi)
-        ic = kr4(i)/ibi;  jc = kr4(i)/ibi  
+        ic = kr4(i)/ibi;  jc = kr4(i)/ibi
         if(C.eq.0.d0) then
-         i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi) 
-         i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi) 
+         i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi)
+         i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi)
          C =  sk_ppqq(i1,i2,i3,i4,k)
         elseif(kr1(i).ne.kr1(i-1).or.kr2(i).ne.kr2(i-1).or. &
                kr3(i).ne.kr3(i-1))  then
-         i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi) 
-         i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi) 
+         i1 = kr2(i)/ibi; i2 = mod(kr2(i),ibi)
+         i3 = kr3(i)/ibi; i4 = mod(kr3(i),ibi)
          C =  sk_ppqq(i1,i2,i3,i4,k)
         end if
         HB(ic,jc) = HB(ic,jc) + crk(i)*C
@@ -235,8 +235,8 @@
       end if
 
       Do i=1,nconf-1; Do j=i+1,nconf
-        HC(i,j) = HC(j,i);  HB(i,j) = HB(i,j)   
-      End do; End do                                                             
+        HC(i,j) = HC(j,i);  HB(i,j) = HB(i,j)
+      End do; End do
 
 !----------------------------------------------------------------------
 ! ... diagonalizing the Hamiltonian matrix:
@@ -263,7 +263,7 @@
         H(i,i) = H(i,i) + H_vacpol(i+i1-1)
        End do
 
-       Call LAP_DSYEV ('V','L',nc,nconf,H,eval,info)     
+       Call LAP_DSYEV ('V','L',nc,nconf,H,eval,info)
 
        ipe = 0
        Do k = 1,nc
@@ -307,23 +307,23 @@
       Do jc=1,nconf;  ic = ipe(jc); etotal = EE_tot(ic)
                       configuration = labels(index(ic)); ii = ilabel
 
-       if(mbreit.eq.0) then 
+       if(mbreit.eq.0) then
 
         write(log,'(a,F25.15,a,3x,F14.5,a)') configuration(1:ii),etotal,' au', &
             (etotal-E1)*au_eV,' eV'
 
-       else  
+       else
         SHELLJ = ' '
         if(jc.eq.1)  write(log,'(a,a16,3a13,a16)') &
                      SHELLJ(1:ii),'Coulomb','Breit','Self','Vacpol','Total'
- 
+
         write(log,'(a,f16.4,3F13.4,f16.5)') configuration(1:ii),EE_coul(ic)*au_eV, &
          EE_breit(ic)*au_eV,EE_self(ic)*au_eV,EE_vacpol(ic)*au_eV,(etotal-E1)*au_eV
        end if
-      
+
       End do ! over configurations, jc
- 
-      End Subroutine State_energies 
+
+      End Subroutine State_energies
 
 
 
@@ -353,7 +353,7 @@
 
        ! ... orbital
 
-       ii=in(i); if(iset.eq.0) ii=0      
+       ii=in(i); if(iset.eq.0) ii=0
        EL=ELi(nn(i),kn(i),ii)
        Do j = 1,5
         if(EL(j:j).eq.' ') Cycle
@@ -363,18 +363,18 @@
        ! ... number of electrons
 
        if(iq(i).gt.0.and.iq(i).le.9) then
-        write(Lab(k:k),'(a)') '('; k=k+1 
+        write(Lab(k:k),'(a)') '('; k=k+1
         write(Lab(k:k),'(i1)') iq(i); k=k+1
-        write(Lab(k:k),'(a)') ')'; k=k+1 
+        write(Lab(k:k),'(a)') ')'; k=k+1
        elseif(iq(i).gt.9) then
-        write(Lab(k:k),'(a)') '('; k=k+1 
+        write(Lab(k:k),'(a)') '('; k=k+1
         write(Lab(k:k+1),'(i2)') iq(i); k=k+2
-        write(Lab(k:k),'(a)') ')'; k=k+1 
+        write(Lab(k:k),'(a)') ')'; k=k+1
        end if
        Lab(k:k)='.'; k=k+1
 
        ! ... shell term
-      
+
        if(Jterm (jn(i),iq(i),-1,JT,JV,JW,JQ).gt.1) then
         k=k-1;  Lab(k:k)='_'; k=k+1
 
@@ -403,7 +403,7 @@
        ! ... intermediate term
 
        if(no.gt.1.and.i.eq.1) Cycle
-       kk = 0 
+       kk = 0
        if(i.gt.1) then
         if(iabs(Jshell(i)-Jintra(i-1)).lt.Jshell(i)+Jintra(i-1)) kk=1
        end if
@@ -440,7 +440,7 @@
 !======================================================================
       Subroutine LAP_DSYEV(job,UPLO,n,m,A,eval,info)
 !======================================================================
-!     Call LAPACK procedure DSYEV to obtain the eigenvalues (eval) and 
+!     Call LAPACK procedure DSYEV to obtain the eigenvalues (eval) and
 !     eigenvectors (A) for Real symmetric matrix A(n,n)
 !     job = 'V' or 'N' - compute or not the eigenvectors
 !     UPLO='U'  or 'L' -  used upper or lower triangle matrix

--- a/DBSR_HF/hf_summry.f90
+++ b/DBSR_HF/hf_summry.f90
@@ -1,7 +1,7 @@
-!====================================================================== 
+!======================================================================
       Subroutine SUMMRY
-!====================================================================== 
-! ... the results of a calculation are summarized in log-file 
+!======================================================================
+! ... the results of a calculation are summarized in log-file
 !----------------------------------------------------------------------
       Use DBS_grid
       Use DF_orbitals
@@ -9,20 +9,20 @@
 
       Implicit none
       Integer :: i,j,m
-      Real(8) :: en, r1,r2,rm1, EV,EK,EM, ratio, TA,VA,AM 
+      Real(8) :: en, r1,r2,rm1, EV,EK,EM, ratio, TA,VA,AM
       Real(8), external :: quadr
 
       write(log,'(/84(''-''))')
-      write(log,'(/a,a)') 'ATOM  ',ATOM 
-      write(log,'(/a,a)') 'core: ',trim(adjustl(core)) 
+      write(log,'(/a,a)') 'ATOM  ',ATOM
+      write(log,'(/a,a)') 'core: ',trim(adjustl(core))
       if(term.eq.'LS') then
        Call Clean_a(conf_LS)
-       write(log,'(/a,a)') 'conf: ',trim(adjustl(conf_LS)) 
+       write(log,'(/a,a)') 'conf: ',trim(adjustl(conf_LS))
       elseif(term.eq.'jj') then
        Call Clean_a(configuration)
-       write(log,'(/a,a)') 'conf: ',trim(adjustl(configuration)) 
+       write(log,'(/a,a)') 'conf: ',trim(adjustl(configuration))
       else
-       write(log,'(/a,a)') 'conf: ',trim(adjustl(conf_AV)) 
+       write(log,'(/a,a)') 'conf: ',trim(adjustl(conf_AV))
       end if
 
 ! ... Compute Moments
@@ -32,18 +32,18 @@
       write(log,*)
 
       EK = 0.d0;  EM = 0.d0;  EV = 0.d0
-      Do I = 1, NWF 
+      Do I = 1, NWF
        Call TVM(kbs(i),p(1,1,i),p(1,2,i),TA,VA,AM)
        EK = EK + TA*qsum(i)
        EV = EV + VA*qsum(i)
        EM = EM + AM*qsum(i)
-       r1  = QUADR(p(1,1,i),p(1,1,i),1) 
+       r1  = QUADR(p(1,1,i),p(1,1,i),1)
        r2  = QUADR(p(1,1,i),p(1,1,i),2)
-       rm1 = QUADR(p(1,1,i),p(1,1,i),-1) 
+       rm1 = QUADR(p(1,1,i),p(1,1,i),-1)
        write(log,'(A5,f16.8,1PD13.2,I8,0P2f10.3)') &
-        ebs(i), e(i,i), dpm(i), mbs(i), r1, t(mbs(i)+ks)  
-      End do 
-      
+        ebs(i), e(i,i), dpm(i), mbs(i), r1, t(mbs(i)+ks)
+      End do
+
       write(log,'(/A,T25,1PD10.2)') 'Orbital convergence:', orb_diff
       write(log,'( A,T25,1PD10.2)') 'Energy  convergence:', scf_diff
 
@@ -74,7 +74,7 @@
        Call Breit_energy(E_breit)
 
        Call Self_energy(E_self)
-       Call VP_energy(E_vacpol)                                  
+       Call VP_energy(E_vacpol)
        write(log,'(/a,T20,F24.15,T50,F24.15)') 'Breit:', E_breit,E_breit*au_eV
        write(log,'( a,T20,F24.15,T50,F24.15)') 'Self-energy:', E_self,E_self*au_eV
        write(log,'( a,T20,F24.15,T50,F24.15)') 'Vacuum polarization:', E_vacpol,E_vacpol*au_eV
@@ -88,15 +88,15 @@
 
       end if
 
-      End Subroutine SUMMRY 
+      End Subroutine SUMMRY
 
 
 
 
-!====================================================================== 
+!======================================================================
       Subroutine Conf_energies
-!====================================================================== 
-! ... output of configuration energies 
+!======================================================================
+! ... output of configuration energies
 ! ... WARNING: weight and qsum are destroited here
 !----------------------------------------------------------------------
       Use DBSR_hf
@@ -113,7 +113,7 @@
                EE_vacpol(nconf), EE_tot(nconf), ipe(nconf) )
       EE_coul=0.d0; EE_breit=0.d0; EE_self=0.d0; EE_vacpol=0.d0
 
-! ... get all energies 
+! ... get all energies
 
       Do ic=1,nconf
        qsum(:) = iqconf(ic,:)
@@ -133,7 +133,7 @@
       End do ! over configurations
 
 ! ... sorting the energies:
- 
+
       Call SORTR(nconf,EE_tot,ipe)
 
       write(log,'(/a/)') 'Configuration energies:'
@@ -160,24 +160,24 @@
         i = i + 9
        End do
 
-       if(mbreit.eq.0) then 
+       if(mbreit.eq.0) then
 
         write(log,'(a,F24.15,a,3x,F24.15,a)') configuration(1:ii),etotal,' au', &
             etotal*au_eV-EE_tot(ipe(1))*au_eV,' eV'
 
-       else  
+       else
 
         if(jc.eq.1) then
          SHELLJ=' '
          write(log,'(a,a16,3a13,a16)') &
          SHELLJ(1:ii),'Coulomb','Breit','Self','Vacpol','Sum'
         end if
- 
+
         write(log,'(a,f16.4,3F13.4,f16.4)') configuration(1:ii),EE_coul(ic)*au_eV, &
          EE_breit(ic)*au_eV,EE_self(ic)*au_eV,EE_vacpol(ic)*au_eV,etotal*au_eV
 
        end if
-      
+
       End do ! over configurations
 
       End Subroutine Conf_energies
@@ -193,8 +193,8 @@
 !--------------------------------------------------------------------
       Implicit none
       Integer, intent(in ) :: n
-      Real(8), intent(in ) :: S(n) 
-      Integer, intent(out) :: IPT(n) 
+      Real(8), intent(in ) :: S(n)
+      Integer, intent(out) :: IPT(n)
       Integer :: i,i1,j1,i2,j2
       Do i=1,n; IPT(i)=i;  End do
       Do i1=1,n-1;    j1=IPT(i1)

--- a/DBSR_HF/makefile
+++ b/DBSR_HF/makefile
@@ -2,26 +2,26 @@
 FC = gfortran
 
 #  FORTRAN options for compilation and link:
-comp = -c -O2   
-link = -O2  
+comp = -c -O2
+link = -O2
 
 # Binary name
-N  = dbsr_hf 
- 
+N  = dbsr_hf
+
 # locate your bin directory with executables if desired:
-BINDIR = ../ 
+BINDIR = ../
 
 # locate LAPACK and BLAS libraries in your computer:
 # many new compilers contain these libraries and you just need to indicate flag "-mkl",
 # or to put -llapack -lblas instead the LAPACK and BLAS variables used below
 
 #LIBDIR = $(HOME)/T/LIBS_new
-#LAPACK = $(LIBDIR)/lapack.a 
-#BLAS =   $(LIBDIR)/blas.a  
+#LAPACK = $(LIBDIR)/lapack.a
+#BLAS =   $(LIBDIR)/blas.a
 LAPACK = -llapack
 BLAS   = -lblas
 
-# source files: 
+# source files:
 S  =    dbsr_lib_zcom.f90            dbsr_lib_zconfjj.f90      dbsr_lib_dbs.f90       \
   	     hf_MOD_dbsr_hf.f90           hf_MOD_df_orbitals.f90    hf_MOD_energy.f90      \
         dbsr_hf.f90                                                                   \
@@ -32,22 +32,22 @@ S  =    dbsr_lib_zcom.f90            dbsr_lib_zconfjj.f90      dbsr_lib_dbs.f90 
         hf_plot_bsw.f90              hf_read_pqbs.f90          hf_read_GRASP.f90      \
         hf_rk.f90                    hf_rotate.f90             hf_sk.f90              \
         hf_solve_HF.f90              hf_state_energies.f90     hf_summry.f90          \
-        
+
 # replace_iargc.f90   ->  needed for some old compilers only
 
 O = $(S:.f90=.o)
- 
+
 $(N): $(O)
-	$(FC) -o $(N) $(O) $(link)  $(LAPACK)  $(BLAS)  
- 
+	$(FC) -o $(N) $(O) $(link)  $(LAPACK)  $(BLAS)
+
 clean:
-	rm -f *.o *.mod 
- 
+	rm -f *.o *.mod
+
 x:
 	rm -f $(N)
- 
+
 .SUFFIXES:
 .SUFFIXES: .f90 .mod .o
- 
+
 .f90.o:
 	$(FC) $(comp) $<

--- a/DBSR_HF/replace_iargc.f90
+++ b/DBSR_HF/replace_iargc.f90
@@ -2,10 +2,9 @@
       Integer Function Iargc()
 !======================================================================
 !     replace iargc from FORTRAN-90
-!     (this routine is absent in some last versions of gfortran) 
+!     (this routine is absent in some last versions of gfortran)
 !----------------------------------------------------------------------
       Implicit none
       iargc = command_argument_count()
       End  Function Iargc
 
-      


### PR DESCRIPTION
The source code is written in Windows which gives `^M`type file endings.

Conversion to UNIX is carried out with
```bash
dos2unix *
```
Trailing white spaces are removed with (replace `sed` with `gsed` for Mac/homebrew)
```bash
find . -type f -exec sed --in-place 's/[[:space:]]\+$//' {} \;
```