### PR TITLE
Stops dbsr_hf if too many peel orbitals are added to prevent crash

### DIFF
--- a/DBSR_HF/hf_get_case.f90
+++ b/DBSR_HF/hf_get_case.f90
@@ -224,6 +224,8 @@
 
       i = 1
       Do j=ncore+1,nwf
+       if(i+11 >= len(conf_AV)) Stop &
+        'Stop: Too many "Peel orbitals", move some to Core in header'
        write(conf_AV(i:),'(a5,a1,f4.1,a1)') &
         ebs(j),'(',qsum(j),')'
        i = i + 11


### PR DESCRIPTION
A pull request that gracefully stops the program with an error message when too many peel orbitals are added in the confs= argument file.

When dbsr_hf runs with the argument confs='file.conf', it may accept GRASP18 rcsf CSF files as an input.

However, because conf_AV is limited by 160 characters, the program crashes with no internal error message when too many peel orbitals are included. This pull request stops the program and notifies the user of this limitation as a workaround.

This would be useful to users, as they would be able to understand the reason for dbsr_hf stopping and deal with this respectively.